### PR TITLE
feat: integrate AI decision-making for trading strategies

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,50 @@
+# ===========================================
+# Bybit Trading Bot Configuration
+# ===========================================
+
+# Bybit API Credentials (required)
+API_KEY=your_bybit_api_key_here
+SECRET_KEY=your_bybit_secret_key_here
+
+# Bybit Environment
+# Options: mainnet, testnet
+BYBIT_ENV=testnet
+
+# ===========================================
+# AI Integration (Anthropic Claude)
+# ===========================================
+
+# Anthropic API Key (required for ai/combined modes)
+# Get your key at: https://console.anthropic.com/
+ANTHROPIC_API_KEY=sk-ant-your-api-key-here
+
+# Decision Mode
+# Options: rules, ai, combined
+# - rules: Original rule-based logic (default)
+# - ai: AI-only decisions
+# - combined: Rules + AI confirmation
+DECISION_MODE=rules
+
+# AI Model (optional)
+# Default: claude-sonnet-4-20250514
+AI_MODEL=claude-sonnet-4-20250514
+
+# AI Request Timeout in seconds (optional)
+# Default: 30
+AI_TIMEOUT=30
+
+# Minimum interval between AI calls in seconds (optional)
+# Default: 60
+AI_CHECK_INTERVAL=60
+
+# Maximum retry attempts for AI requests (optional)
+# Default: 3
+AI_MAX_RETRIES=3
+
+# ===========================================
+# Logging (optional)
+# ===========================================
+
+# Log Level
+# Options: DEBUG, INFO, WARNING, ERROR, CRITICAL
+LOG_LEVEL=INFO

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,12 @@
 __pycache__
 .git
 .mypy_cache
+# Environment
 .env
+.env.local
+.env.*.local
+# Don't ignore the example
+!.env.example
 .trunk
 .pylintrc
 bybit.txt

--- a/README.md
+++ b/README.md
@@ -12,12 +12,18 @@ pip install -r requirements.txt
 
 ## Configuration
 
-1. Create a `.env` file in the project root directory
-2. Add your Bybit API keys to it:
+1. Copy `.env.example` to `.env`:
+```bash
+cp .env.example .env
+```
+
+2. Edit `.env` and add your Bybit API keys:
 ```
 API_KEY=your_api_key
 SECRET_KEY=your_secret_key
 ```
+
+For AI integration, also add your Anthropic API key (see AI Integration section below).
 
 ### Whitelist Configuration (Optional)
 
@@ -57,9 +63,39 @@ python bot.py 100
 
 For whitelist mode, you need to configure the `whitelist.txt` file (see configuration section below).
 
-Parameters:
+### Examples with Decision Modes
+
+**Rules mode (default)** — uses only price-based rules:
+```bash
+# Single-coin
+python bot.py 100 WIF
+
+# Whitelist
+python bot.py 100
+```
+
+**AI mode** — AI makes all entry decisions:
+```bash
+# Single-coin with AI
+python bot.py 100 WIF --mode ai
+
+# Whitelist with AI
+python bot.py 100 --mode ai
+```
+
+**Combined mode** — rules trigger first, then AI confirms:
+```bash
+# Single-coin with AI confirmation
+python bot.py 100 WIF --mode combined
+
+# Whitelist with AI confirmation
+python bot.py 100 --mode combined
+```
+
+### Parameters
 - `buy_amount`: Amount in USDT to buy
 - `coin`: Cryptocurrency to trade (e.g., XRP, BTC, ETH) - only for single-coin mode
+- `--mode`: Decision mode - `rules` (default), `ai`, or `combined` (see AI Integration section)
 
 ## Current Features
 
@@ -140,6 +176,110 @@ Test logs are saved with the prefix `TEST_` in the filename for easy identificat
 - The `test_place_order` function is commented out by default for safety
 - Only enable order testing if you understand it will use real funds
 - Test with small amounts first
+
+## AI Integration
+
+The bot supports AI-powered trading decisions using Anthropic Claude.
+
+### Decision Modes
+
+| Mode | Description |
+|------|-------------|
+| `rules` | Original rule-based logic (price thresholds). Default mode. |
+| `ai` | AI makes all entry decisions. Falls back to rules on error. |
+| `combined` | Rules must trigger first, then AI confirms/vetoes the signal. |
+
+### Setup
+
+1. Get an API key from [Anthropic Console](https://console.anthropic.com/)
+
+2. Add to your `.env` file:
+   ```env
+   ANTHROPIC_API_KEY=sk-ant-your-key-here
+   DECISION_MODE=combined  # or 'ai' or 'rules'
+   ```
+
+3. Run with desired mode:
+   ```bash
+   # Use mode from .env
+   python bot.py 100 WIF
+
+   # Override with command line
+   python bot.py 100 WIF --mode ai
+   python bot.py 100 --whitelist --mode combined
+   ```
+
+### Configuration Options
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `ANTHROPIC_API_KEY` | - | Required for ai/combined modes |
+| `DECISION_MODE` | `rules` | Default decision mode |
+| `AI_MODEL` | `claude-sonnet-4-20250514` | Anthropic model to use |
+| `AI_TIMEOUT` | `30` | Request timeout in seconds |
+| `AI_CHECK_INTERVAL` | `60` | Minimum seconds between AI calls |
+| `AI_MAX_RETRIES` | `3` | Max retry attempts on error |
+
+### How It Works
+
+#### AI Mode
+```
+Price data → AI analyzes → Buy/Hold decision
+                ↓ (on error)
+           Falls back to rules
+```
+
+#### Combined Mode
+```
+Price data → Rules check → No signal → Hold
+                ↓
+           Signal triggered → AI confirmation → Buy/Hold
+                                    ↓ (on error)
+                               Falls back to rules
+```
+
+### Cost Considerations
+
+- Each AI call uses approximately 200-400 tokens
+- Caching prevents redundant calls when price changes < 0.5%
+- Minimum interval between calls is configurable (default: 60s)
+- Combined mode only calls AI when rules trigger (most cost-efficient)
+
+### Monitoring
+
+Check logs for AI activity:
+```
+INFO - AI decision for WIFUSDT: buy (reasoning: Strong momentum...)
+INFO - Using cached AI decision for WIFUSDT: hold
+WARNING - Rate limited by Anthropic API, waiting 30.0s
+```
+
+### Troubleshooting
+
+| Issue | Solution |
+|-------|----------|
+| "ANTHROPIC_API_KEY not found" | Add key to .env file |
+| "Rate limited" | Increase AI_CHECK_INTERVAL |
+| "Failed after X attempts" | Check network, increase AI_MAX_RETRIES |
+| AI always says "hold" | Review AI prompt, check market conditions |
+
+## Project Structure
+
+```
+bybit_bot/
+├── bot.py              # Entry point, argument parsing
+├── helpers.py          # Bybit API wrapper
+├── strategies.py       # Trading strategies
+├── ai_client.py        # AI client for Anthropic API
+├── ai_config.py        # AI configuration and prompts
+├── logger.py           # Logging configuration
+├── tests.py            # Unit tests
+├── whitelist.txt       # Coin whitelist
+├── requirements.txt    # Python dependencies
+├── .env                # Configuration (not in git)
+├── .env.example        # Configuration template
+└── logs/               # Log files
+```
 
 ## Development Plans
 

--- a/ai_client.py
+++ b/ai_client.py
@@ -1,0 +1,620 @@
+"""
+AI Client Module
+
+Provides integration with Anthropic Claude API
+for making trading decisions.
+"""
+
+import json
+import logging
+import time
+from dataclasses import dataclass
+from typing import Optional
+
+import anthropic
+
+from ai_config import (
+    DEFAULT_CHECK_INTERVAL,
+    DEFAULT_MAX_RETRIES,
+    DEFAULT_MODEL,
+    DEFAULT_TIMEOUT,
+    PRICE_CHANGE_THRESHOLD,
+    SYSTEM_PROMPT,
+    format_user_prompt,
+)
+
+
+class AIError(Exception):
+    """Exception for AI errors"""
+
+    pass
+
+
+@dataclass
+class AIDecision:
+    """AI decision result about buying"""
+
+    decision: str  # "buy" or "hold"
+    reasoning: str  # decision reasoning
+    raw_response: Optional[str] = None  # raw response for debugging
+
+    @property
+    def should_buy(self) -> bool:
+        """Convert decision to bool"""
+        return self.decision.lower() == "buy"
+
+
+@dataclass
+class AIClientState:
+    """
+    Internal state of the AI client.
+    Used for caching and rate limiting.
+    """
+
+    last_call_time: float = 0.0  # time of last successful call
+    last_price: float = 0.0  # price at last call
+    last_symbol: str = ""  # symbol at last call
+    consecutive_errors: int = 0  # consecutive errors counter
+    current_interval: int = 60  # current interval between calls
+
+
+class AIClient:
+    """
+    Client for interacting with Anthropic Claude API.
+
+    Attributes:
+        api_key: Anthropic API key
+        model: Claude model to use
+        timeout: Request timeout in seconds
+        max_retries: Maximum number of retry attempts
+        check_interval: Interval between AI calls in seconds
+        state: Internal client state
+    """
+
+    def __init__(
+        self,
+        api_key: str,
+        model: str = DEFAULT_MODEL,
+        timeout: int = DEFAULT_TIMEOUT,
+        max_retries: int = DEFAULT_MAX_RETRIES,
+        check_interval: int = DEFAULT_CHECK_INTERVAL,
+    ):
+        """
+        Initialize the AI client.
+
+        Args:
+            api_key: Anthropic API key
+            model: Claude model (default claude-sonnet-4-20250514)
+            timeout: Request timeout in seconds (default 30)
+            max_retries: Maximum retry attempts (default 3)
+            check_interval: Interval between calls in seconds (default 60)
+
+        Raises:
+            AIError: On client initialization error
+        """
+        if not api_key:
+            raise AIError("API key is required")
+
+        self.api_key = api_key
+        self.model = model
+        self.timeout = timeout
+        self.max_retries = max_retries
+        self.default_interval = check_interval
+
+        # Parameters for exponential backoff
+        self.base_delay = 2.0  # Base delay in seconds
+        self.max_delay = 60.0  # Maximum delay in seconds
+
+        # Price change threshold for caching
+        self.price_change_threshold = PRICE_CHANGE_THRESHOLD
+
+        # Internal state
+        self.state = AIClientState(current_interval=check_interval)
+
+        # Cached last decision
+        self._last_decision: Optional[AIDecision] = None
+
+        # Initialize Anthropic client
+        try:
+            self.client = anthropic.Anthropic(api_key=api_key, timeout=timeout)
+            logging.info(f"AIClient initialized (model: {model}, timeout: {timeout}s)")
+        except Exception as e:
+            raise AIError(f"Failed to initialize Anthropic client: {e}") from e
+
+    def should_buy(
+        self,
+        symbol: str,
+        current_price: float,
+        change_1h: float,
+        change_3h: float,
+        force: bool = False,
+    ) -> AIDecision:
+        """
+        Make a buying decision with caching and retry logic.
+
+        Args:
+            symbol: Trading pair (e.g., "WIFUSDT")
+            current_price: Current price in USDT
+            change_1h: Price change over 1 hour (%)
+            change_3h: Price change over 3 hours (%)
+            force: Force AI call (ignores cache)
+
+        Returns:
+            AIDecision with decision and reasoning
+
+        Raises:
+            AIError: When all attempts are exhausted
+        """
+        # Check if AI call is needed
+        if not force and not self.is_call_needed(symbol, current_price):
+            cached = self.get_cached_decision()
+            if cached is not None:
+                logging.info(
+                    f"Using cached AI decision for {symbol}: {cached.decision}"
+                )
+                return cached
+            # If no cache, still call AI
+            logging.debug("No cached decision, proceeding with AI call")
+
+        user_prompt = format_user_prompt(symbol, current_price, change_1h, change_3h)
+
+        last_error: Optional[Exception] = None
+
+        for attempt in range(self.max_retries):
+            try:
+                logging.debug(
+                    f"AI request attempt {attempt + 1}/{self.max_retries} "
+                    f"for {symbol} @ {current_price}"
+                )
+
+                response = self.client.messages.create(
+                    model=self.model,
+                    max_tokens=256,
+                    system=SYSTEM_PROMPT,
+                    messages=[{"role": "user", "content": user_prompt}],
+                )
+
+                content_block = response.content[0]
+                if not hasattr(content_block, "text"):
+                    raise AIError(
+                        f"Unexpected response block type: {type(content_block).__name__}"
+                    )
+                raw_response: str = content_block.text  # type: ignore[union-attr]
+                logging.debug(f"AI raw response: {raw_response[:200]}")
+
+                # Parse the response
+                decision = self._parse_response(raw_response)
+
+                # Successful call — update state with caching
+                self._update_state(symbol, current_price, decision)
+
+                logging.info(
+                    f"AI decision for {symbol}: {decision.decision} "
+                    f"(reasoning: {decision.reasoning[:100]}...)"
+                )
+
+                return decision
+
+            except anthropic.RateLimitError as e:
+                # HTTP 429 — rate limit
+                last_error = e
+                self.state.consecutive_errors += 1
+
+                # Check for critical error count
+                if self.state.consecutive_errors > 10:
+                    logging.critical(
+                        f"Critical: {self.state.consecutive_errors} consecutive errors detected. "
+                        f"AI service may be unavailable."
+                    )
+
+                # Extract retry_after from response (if available)
+                retry_after = self._extract_retry_after(e)
+                wait_time = self._handle_rate_limit(retry_after)
+
+                if attempt < self.max_retries - 1:
+                    logging.warning(
+                        f"Rate limit hit, retrying in {wait_time:.1f}s "
+                        f"(attempt {attempt + 1}/{self.max_retries})"
+                    )
+                    time.sleep(wait_time)
+
+            except anthropic.APIStatusError as e:
+                # Other API errors (500, 503, etc.)
+                last_error = e
+                self.state.consecutive_errors += 1
+
+                # Check for critical error count
+                if self.state.consecutive_errors > 10:
+                    logging.critical(
+                        f"Critical: {self.state.consecutive_errors} consecutive errors detected. "
+                        f"AI service may be unavailable."
+                    )
+
+                wait_time = self._calculate_backoff_delay(attempt)
+
+                logging.error(
+                    f"Anthropic API error: {e.status_code} - {e.message} "
+                    f"(attempt {attempt + 1}/{self.max_retries})"
+                )
+
+                if attempt < self.max_retries - 1:
+                    logging.info(f"Retrying in {wait_time:.1f}s")
+                    time.sleep(wait_time)
+
+            except anthropic.APIConnectionError as e:
+                # Connection errors (network unavailable, etc.)
+                last_error = e
+                self.state.consecutive_errors += 1
+
+                # Check for critical error count
+                if self.state.consecutive_errors > 10:
+                    logging.critical(
+                        f"Critical: {self.state.consecutive_errors} consecutive errors detected. "
+                        f"AI service may be unavailable."
+                    )
+
+                wait_time = self._calculate_backoff_delay(attempt)
+
+                logging.error(
+                    f"Anthropic API connection error: {e} "
+                    f"(attempt {attempt + 1}/{self.max_retries})"
+                )
+
+                if attempt < self.max_retries - 1:
+                    logging.info(f"Retrying in {wait_time:.1f}s")
+                    time.sleep(wait_time)
+
+            except AIError:
+                # Parsing errors — raise immediately, retry won't help
+                raise
+
+            except Exception as e:
+                # Unexpected errors
+                last_error = e
+                self.state.consecutive_errors += 1
+
+                # Check for critical error count
+                if self.state.consecutive_errors > 10:
+                    logging.critical(
+                        f"Critical: {self.state.consecutive_errors} consecutive errors detected. "
+                        f"AI service may be unavailable."
+                    )
+
+                wait_time = self._calculate_backoff_delay(attempt)
+
+                logging.error(
+                    f"Unexpected error calling AI: {type(e).__name__}: {e} "
+                    f"(attempt {attempt + 1}/{self.max_retries})"
+                )
+
+                if attempt < self.max_retries - 1:
+                    logging.info(f"Retrying in {wait_time:.1f}s")
+                    time.sleep(wait_time)
+
+        # All retries exhausted
+        error_message = f"Failed to get AI decision after {self.max_retries} attempts"
+        if last_error:
+            error_message += f": {type(last_error).__name__}: {last_error}"
+
+        logging.critical(error_message)
+        raise AIError(error_message)
+
+    def is_call_needed(self, symbol: str, current_price: float) -> bool:
+        """
+        Check if AI call is needed or cached result can be used.
+
+        Caching logic:
+        1. First call (no history) — always call AI
+        2. Symbol changed — always call AI (reset cache)
+        3. Less than current_interval seconds passed — don't call
+        4. Price change < PRICE_CHANGE_THRESHOLD from last call — don't call
+
+        Args:
+            symbol: Trading pair (e.g., "BTCUSDT")
+            current_price: Current price in USDT
+
+        Returns:
+            True if AI call is needed, False if can be skipped
+        """
+        now = time.time()
+
+        # 1. First call — always request AI
+        if self.state.last_call_time == 0.0:
+            logging.debug(f"AI call needed: first call for {symbol}")
+            return True
+
+        # 2. Symbol changed — reset cache and request
+        if self.state.last_symbol != symbol:
+            logging.debug(
+                f"AI call needed: symbol changed from {self.state.last_symbol} to {symbol}"
+            )
+            return True
+
+        # 3. Check time interval
+        time_since_last_call = now - self.state.last_call_time
+        if time_since_last_call < self.state.current_interval:
+            remaining = self.state.current_interval - time_since_last_call
+            logging.debug(
+                f"AI call skipped: too soon, {remaining:.1f}s remaining "
+                f"(interval: {self.state.current_interval}s)"
+            )
+            return False
+
+        # 4. Check price change
+        if self.state.last_price > 0:
+            price_change_pct = abs(
+                (current_price - self.state.last_price) / self.state.last_price * 100
+            )
+            if price_change_pct < self.price_change_threshold:
+                logging.debug(
+                    f"AI call skipped: price change too small ({price_change_pct:.3f}% < {self.price_change_threshold}%)"
+                )
+                return False
+            else:
+                logging.debug(
+                    f"AI call needed: significant price change ({price_change_pct:.3f}% >= {self.price_change_threshold}%)"
+                )
+
+        logging.debug(
+            "AI call needed: interval elapsed and price changed significantly"
+        )
+        return True
+
+    def _extract_json_from_response(self, raw_response: str) -> str:
+        """
+        Extract JSON from AI response, removing markdown formatting.
+
+        AI sometimes wraps JSON in markdown code blocks.
+        This method cleans the response from such formatting.
+
+        Args:
+            raw_response: Raw response from AI
+
+        Returns:
+            Cleaned JSON string
+        """
+        import re
+
+        cleaned = raw_response.strip()
+
+        # Pattern for markdown code block: ```json ... ``` or ``` ... ```
+        patterns = [
+            r"^```json\s*\n?(.*?)\n?\s*```$",  # ```json ... ```
+            r"^```\s*\n?(.*?)\n?\s*```$",  # ``` ... ```
+        ]
+
+        for pattern in patterns:
+            match = re.match(pattern, cleaned, re.DOTALL)
+            if match:
+                return match.group(1).strip()
+
+        return cleaned
+
+    def _parse_response(self, raw_response: str) -> AIDecision:
+        """
+        Parse AI response with validation.
+
+        Handles:
+        - Invalid JSON
+        - Missing required decision field
+        - Unexpected decision values
+        - Missing reasoning field (optional)
+
+        Args:
+            raw_response: Raw text response from AI
+
+        Returns:
+            AIDecision with parsed data
+
+        Raises:
+            AIError: On invalid JSON or missing required fields
+        """
+        # Extract JSON from response
+        cleaned_response = self._extract_json_from_response(raw_response)
+
+        # Parse JSON
+        try:
+            data = json.loads(cleaned_response)
+        except json.JSONDecodeError as e:
+            logging.error(f"AI returned invalid JSON: {raw_response[:200]}")
+            raise AIError(f"Invalid JSON from AI: {e}") from e
+
+        # Verify it's a dictionary
+        if not isinstance(data, dict):
+            logging.error(f"AI response is not a JSON object: {type(data)}")
+            raise AIError(
+                f"AI response must be a JSON object, got: {type(data).__name__}"
+            )
+
+        # Check required decision field
+        if "decision" not in data:
+            logging.error(f"AI response missing 'decision' field: {data}")
+            raise AIError("Missing 'decision' field in AI response")
+
+        # Extract and normalize decision
+        raw_decision = data.get("decision")
+        if not isinstance(raw_decision, str):
+            logging.error(f"'decision' field is not a string: {type(raw_decision)}")
+            raise AIError(
+                f"'decision' must be a string, got: {type(raw_decision).__name__}"
+            )
+
+        decision = raw_decision.lower().strip()
+
+        # Validate decision value
+        valid_decisions = ["buy", "hold"]
+        if decision not in valid_decisions:
+            logging.warning(
+                f"AI returned unexpected decision '{raw_decision}', treating as 'hold'"
+            )
+            decision = "hold"
+
+        # Extract reasoning (optional)
+        reasoning = data.get("reasoning", "")
+        if not isinstance(reasoning, str):
+            reasoning = str(reasoning)
+        if not reasoning.strip():
+            reasoning = "No reasoning provided"
+
+        return AIDecision(
+            decision=decision, reasoning=reasoning.strip(), raw_response=raw_response
+        )
+
+    def _handle_rate_limit(self, retry_after: Optional[int] = None) -> float:
+        """
+        Handle HTTP 429 Rate Limit from Anthropic API.
+
+        When receiving rate limit:
+        1. Use retry_after value from header (if available)
+        2. Otherwise apply exponential backoff
+        3. Increase interval between calls to reduce load
+
+        Args:
+            retry_after: Value from Retry-After header (in seconds)
+
+        Returns:
+            Wait time in seconds
+        """
+        # Determine wait time
+        if retry_after is not None and retry_after > 0:
+            wait_time = float(retry_after)
+        else:
+            # Exponential backoff: base_delay * 2^(consecutive_errors)
+            wait_time = min(
+                self.base_delay * (2**self.state.consecutive_errors), self.max_delay
+            )
+
+        logging.warning(
+            f"Rate limited by Anthropic API, waiting {wait_time:.1f}s "
+            f"(consecutive errors: {self.state.consecutive_errors})"
+        )
+
+        # Increase check interval to reduce load
+        new_interval = min(
+            self.state.current_interval * 2, 300  # Maximum 5 minutes between checks
+        )
+        if new_interval != self.state.current_interval:
+            logging.info(
+                f"Increasing check interval: {self.state.current_interval}s -> {new_interval}s"
+            )
+            self.state.current_interval = new_interval
+
+        return wait_time
+
+    def _calculate_backoff_delay(self, attempt: int) -> float:
+        """
+        Calculate delay for retry with exponential backoff.
+
+        Formula: min(base_delay * 2^attempt, max_delay)
+
+        Examples (base_delay=2, max_delay=60):
+        - attempt 0: 2 * 2^0 = 2 seconds
+        - attempt 1: 2 * 2^1 = 4 seconds
+        - attempt 2: 2 * 2^2 = 8 seconds
+        - attempt 3: 2 * 2^3 = 16 seconds
+        - attempt 4: 2 * 2^4 = 32 seconds
+        - attempt 5: min(64, 60) = 60 seconds
+
+        Args:
+            attempt: Attempt number (0-based)
+
+        Returns:
+            Delay in seconds
+        """
+        return min(self.base_delay * (2**attempt), self.max_delay)
+
+    def _extract_retry_after(self, error: anthropic.RateLimitError) -> Optional[int]:
+        """
+        Extract retry-after value from rate limit error.
+
+        Args:
+            error: RateLimitError exception
+
+        Returns:
+            retry-after value in seconds or None
+        """
+        if hasattr(error, "response") and error.response is not None:
+            retry_after_header = error.response.headers.get("retry-after")
+            if retry_after_header:
+                try:
+                    return int(retry_after_header)
+                except ValueError:
+                    pass
+        return None
+
+    def _update_state(
+        self, symbol: str, price: float, decision: Optional[AIDecision] = None
+    ) -> None:
+        """
+        Update state after successful AI call.
+
+        Args:
+            symbol: Trading pair
+            price: Current price
+            decision: AI decision (optional, for caching)
+        """
+        self.state.last_call_time = time.time()
+        self.state.last_price = price
+        self.state.last_symbol = symbol
+        self.state.consecutive_errors = 0
+
+        # Cache the decision
+        if decision is not None:
+            self._last_decision = decision
+
+        # Restore interval after successful call
+        if self.state.current_interval != self.default_interval:
+            logging.info(
+                f"Restoring check interval: {self.state.current_interval}s -> {self.default_interval}s"
+            )
+            self.state.current_interval = self.default_interval
+
+    def get_cached_decision(self) -> Optional[AIDecision]:
+        """
+        Return the last cached decision.
+
+        Used when is_call_needed() returns False.
+
+        Returns:
+            Last AIDecision or None if cache is empty
+        """
+        return self._last_decision
+
+    def reset_cache(self) -> None:
+        """
+        Force reset the AI client cache.
+
+        Used when:
+        - Configuration changes
+        - Manual reset by user
+        - In tests
+        """
+        self.state = AIClientState(current_interval=self.default_interval)
+        self._last_decision = None
+        logging.info("AI client cache reset")
+
+    def get_cache_info(self) -> dict:
+        """
+        Return information about current cache state.
+
+        Useful for debugging and monitoring.
+
+        Returns:
+            Dictionary with cache information
+        """
+        now = time.time()
+        time_since_last_call = (
+            now - self.state.last_call_time if self.state.last_call_time > 0 else None
+        )
+
+        return {
+            "last_symbol": self.state.last_symbol or None,
+            "last_price": self.state.last_price if self.state.last_price > 0 else None,
+            "last_call_seconds_ago": time_since_last_call,
+            "current_interval": self.state.current_interval,
+            "consecutive_errors": self.state.consecutive_errors,
+            "has_cached_decision": self._last_decision is not None,
+            "cached_decision": (
+                self._last_decision.decision if self._last_decision else None
+            ),
+        }

--- a/ai_config.py
+++ b/ai_config.py
@@ -1,0 +1,132 @@
+"""
+AI Configuration Module
+
+Contains constants, prompts, and validation functions
+for AI integration in the trading bot.
+"""
+
+import os
+from typing import Optional
+
+# === Default constants ===
+DEFAULT_MODEL = "claude-sonnet-4-20250514"
+DEFAULT_TIMEOUT = 30  # seconds
+DEFAULT_CHECK_INTERVAL = 60  # seconds
+DEFAULT_MAX_RETRIES = 3
+PRICE_CHANGE_THRESHOLD = 0.5  # % for caching
+
+# === Valid modes ===
+VALID_MODES = ["rules", "ai", "combined"]
+
+# === System prompt for AI ===
+SYSTEM_PROMPT = """You are a cryptocurrency trading assistant. Your task is to analyze price data and decide whether to buy a cryptocurrency.
+
+You will receive:
+- Symbol: the cryptocurrency trading pair (e.g., BTCUSDT)
+- Current price in USDT
+- Price change over the last 1 hour (percentage)
+- Price change over the last 3 hours (percentage)
+
+Based on this data, you must decide:
+- "buy" - if conditions are favorable for entering a position
+- "hold" - if you recommend waiting
+
+Consider these factors:
+1. A drop of 3% or more over 3 hours may indicate a buying opportunity (potential rebound)
+2. A quick rise of 3% or more over 1 hour may indicate momentum worth following
+3. High volatility (large swings in short periods) may suggest waiting for stabilization
+
+Respond ONLY with a valid JSON object in this exact format:
+{
+  "decision": "buy" or "hold",
+  "reasoning": "Brief explanation of your decision in 1-2 sentences"
+}
+
+Do not include any other text outside the JSON object."""
+
+# === User prompt template ===
+USER_PROMPT_TEMPLATE = """Analyze this cryptocurrency data and decide whether to buy:
+
+Symbol: {symbol}
+Current price: {current_price} USDT
+Price change (1 hour): {change_1h:+.2f}%
+Price change (3 hours): {change_3h:+.2f}%
+
+Provide your decision in JSON format."""
+
+
+def get_ai_config() -> dict:
+    """
+    Read AI configuration from environment variables.
+    
+    Returns:
+        dict: AI configuration with fields:
+            - api_key: str | None
+            - model: str
+            - timeout: int
+            - check_interval: int
+            - max_retries: int
+    """
+    return {
+        "api_key": os.getenv("ANTHROPIC_API_KEY"),
+        "model": os.getenv("AI_MODEL", DEFAULT_MODEL),
+        "timeout": int(os.getenv("AI_TIMEOUT", str(DEFAULT_TIMEOUT))),
+        "check_interval": int(os.getenv("AI_CHECK_INTERVAL", str(DEFAULT_CHECK_INTERVAL))),
+        "max_retries": int(os.getenv("AI_MAX_RETRIES", str(DEFAULT_MAX_RETRIES))),
+    }
+
+
+def validate_ai_config(mode: str) -> Optional[str]:
+    """
+    Validate AI configuration for the given mode.
+    
+    Args:
+        mode: Operating mode ("rules", "ai", "combined")
+        
+    Returns:
+        None if configuration is valid, otherwise error message string
+    """
+    if mode not in VALID_MODES:
+        return f"Invalid mode: '{mode}'. Valid modes: {', '.join(VALID_MODES)}"
+    
+    # AI is not required for rules mode
+    if mode == "rules":
+        return None
+    
+    # API key is required for ai and combined modes
+    api_key = os.getenv("ANTHROPIC_API_KEY")
+    if not api_key:
+        return f"ANTHROPIC_API_KEY not found in .env. Required for mode: {mode}"
+    
+    # Optional key format validation
+    if not api_key.startswith("sk-ant-"):
+        # Warning only, not an error
+        import logging
+        logging.warning(
+            "ANTHROPIC_API_KEY doesn't match expected format (sk-ant-...). "
+            "Verify the key is correct."
+        )
+    
+    return None
+
+
+def format_user_prompt(symbol: str, current_price: float, 
+                       change_1h: float, change_3h: float) -> str:
+    """
+    Format user prompt with data.
+    
+    Args:
+        symbol: Trading pair (e.g., "WIFUSDT")
+        current_price: Current price in USDT
+        change_1h: Price change over 1 hour (%)
+        change_3h: Price change over 3 hours (%)
+        
+    Returns:
+        Formatted prompt
+    """
+    return USER_PROMPT_TEMPLATE.format(
+        symbol=symbol,
+        current_price=current_price,
+        change_1h=change_1h,
+        change_3h=change_3h
+    )

--- a/bot.py
+++ b/bot.py
@@ -19,6 +19,7 @@ Supports two modes:
 import os
 import sys
 import logging
+import argparse
 from dotenv import load_dotenv
 from pybit import exceptions
 from pybit.unified_trading import HTTP
@@ -26,6 +27,8 @@ from helpers import BybitHelper
 from tests import test_connection
 from strategies import run_trailing_stop_strategy, run_trailing_stop_strategy_whitelist
 from logger import setup_logger
+from ai_config import validate_ai_config
+from ai_client import AIClient
 
 load_dotenv()
 
@@ -34,17 +37,146 @@ SECRET_KEY = os.getenv("SECRET_KEY")
 WHITELIST_FILE = "whitelist.txt"
 
 
+def create_argument_parser() -> argparse.ArgumentParser:
+    """
+    Create command line argument parser.
+    Integrates new --mode parameter with existing positional arguments.
+    """
+    parser = argparse.ArgumentParser(
+        description="Bybit Trading Bot with AI integration",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+  python bot.py 100 WIF                    # Single-coin, rules mode (default)
+  python bot.py 100 WIF --mode ai          # Single-coin, AI mode
+  python bot.py 100 WIF --mode combined    # Single-coin, combined mode
+  python bot.py 100                        # Whitelist, rules mode
+  python bot.py 100 --mode ai              # Whitelist with AI
+
+Environment:
+  DECISION_MODE       Default mode (overridden by --mode)
+  ANTHROPIC_API_KEY   API key for ai/combined modes
+        """
+    )
+    parser.add_argument(
+        "buy_amount",
+        type=float,
+        help="Purchase amount in USDT"
+    )
+    parser.add_argument(
+        "coin",
+        nargs="?",
+        default=None,
+        help="Coin (e.g., WIF). Not specified in whitelist mode"
+    )
+    parser.add_argument(
+        "--mode",
+        choices=["rules", "ai", "combined"],
+        default=None,
+        help="Decision mode: rules (default), ai, combined"
+    )
+    return parser
+
+
+def get_decision_mode(args: argparse.Namespace) -> str:
+    """
+    Determine decision mode with priority:
+    CLI (--mode) > .env (DECISION_MODE) > default ("rules")
+
+    Args:
+        args: Parsed command line arguments
+
+    Returns:
+        Mode string: "rules", "ai" or "combined"
+    """
+    valid_modes = ["rules", "ai", "combined"]
+
+    # 1. CLI parameter priority
+    if args.mode is not None:
+        logging.info(f"Decision mode: {args.mode} (from CLI)")
+        return args.mode  # Already validated by argparse
+
+    # 2. Check .env
+    env_mode = os.getenv("DECISION_MODE", "").strip().lower()
+    if env_mode:
+        if env_mode not in valid_modes:
+            logging.error(
+                f"Invalid DECISION_MODE in .env: '{env_mode}'. "
+                f"Valid values: {', '.join(valid_modes)}"
+            )
+            sys.exit(1)
+        logging.info(f"Decision mode: {env_mode} (from .env)")
+        return env_mode
+
+    # 3. Default value
+    logging.info("Decision mode: rules (default)")
+    return "rules"
+
+
+def init_ai_client(mode: str) -> 'AIClient | None':
+    """
+    Initialize AI client if required for the mode.
+
+    Args:
+        mode: Operating mode
+
+    Returns:
+        AIClient or None for rules mode
+    """
+    if mode == "rules":
+        return None
+
+    # Configuration validation
+    error = validate_ai_config(mode)
+    if error:
+        logging.error(error)
+        sys.exit(1)
+
+    # Get configuration
+    from ai_config import get_ai_config
+    config = get_ai_config()
+
+    # Create client
+    try:
+        client = AIClient(
+            api_key=config["api_key"],
+            model=config["model"],
+            timeout=config["timeout"],
+            max_retries=config["max_retries"],
+            check_interval=config["check_interval"]
+        )
+        return client
+    except Exception as e:
+        logging.error(f"Failed to initialize AI client: {e}")
+        sys.exit(1)
+
+
 def print_usage():
     """Prints script usage information"""
     print("Usage:")
-    print("  Single-coin mode: python bot.py <buy_amount> <coin>")
-    print("  Whitelist mode:   python bot.py <buy_amount>")
+    print("  Single-coin mode: python bot.py <buy_amount> <coin> [--mode MODE]")
+    print("  Whitelist mode:   python bot.py <buy_amount> [--mode MODE]")
+    print()
+    print("Arguments:")
+    print("  buy_amount          Purchase amount in USDT")
+    print("  coin                Coin (e.g., WIF)")
+    print()
+    print("Options:")
+    print("  --mode              Decision mode:")
+    print("                        rules    - rules only (default)")
+    print("                        ai       - AI only")
+    print("                        combined - rules + AI confirmation")
     print()
     print("Examples:")
-    print("  python bot.py 100 WIF     # Trade only WIF")
-    print("  python bot.py 100         # Trade coins from whitelist.txt")
+    print("  python bot.py 100 WIF              # Trade WIF, rules mode")
+    print("  python bot.py 100 WIF --mode ai    # Trade WIF, AI mode")
+    print("  python bot.py 100 --mode combined  # Whitelist, combined mode")
     print()
-    print("For whitelist mode, create a 'whitelist.txt' file with comma-separated coin names:")
+    print("Environment:")
+    print("  DECISION_MODE       Default mode (overridden by --mode)")
+    print("  ANTHROPIC_API_KEY   API key for ai/combined modes")
+    print()
+    print("For whitelist mode, create 'whitelist.txt' with comma-separated coin names:")
     print("  XRP,ETH,BTC,ADA,DOGE")
     sys.exit(1)
 
@@ -97,38 +229,39 @@ def load_whitelist():
 def main():
     """
     Main function for executing Bybit trading bot operations.
-
-    This function supports two modes:
-    1. Single-coin mode: Trades one specific coin
-    2. Whitelist mode: Scans multiple coins from whitelist and trades the best opportunity
-
-    Command line arguments:
-    - Single-coin: python bot.py <buy_amount> <coin>
-    - Whitelist: python bot.py <buy_amount>
-
-    Exceptions:
-        exceptions.InvalidRequestError: If there's an error in API request
-        exceptions.FailedRequestError: If API request fails
     """
-    # Check command line arguments
-    if len(sys.argv) < 2 or len(sys.argv) > 3:
-        print_usage()
+    load_dotenv()
+
+    # Parse arguments with argparse
+    parser = create_argument_parser()
+
+    # Check minimum number of arguments
+    if len(sys.argv) < 2:
+        parser.print_help()
+        sys.exit(1)
 
     try:
-        buy_amount = float(sys.argv[1])
-        if buy_amount <= 0:
-            raise ValueError("buy_amount must be positive")
-    except ValueError as e:
-        if "could not convert" in str(e):
-            print("Error: buy_amount must be a number")
-        else:
-            print(f"Error: {str(e)}")
-        print_usage()
+        args = parser.parse_args()
+    except SystemExit:
+        sys.exit(1)
 
-    # Determine mode based on number of arguments
-    if len(sys.argv) == 3:
+    # Validate buy_amount
+    if args.buy_amount <= 0:
+        print("Error: buy_amount must be positive")
+        sys.exit(1)
+
+    buy_amount = args.buy_amount
+
+    # Determine mode (CLI > .env > default)
+    decision_mode = get_decision_mode(args)
+
+    # Initialize AI client if needed
+    ai_client = init_ai_client(decision_mode)
+
+    # Determine operating mode (single-coin or whitelist)
+    if args.coin is not None:
         # Single-coin mode
-        coin = sys.argv[2].upper()
+        coin = args.coin.upper()
         mode = "single"
         logging_identifier = coin
     else:
@@ -161,22 +294,32 @@ def main():
         if mode == "single":
             # Single-coin mode
             logging.info(f"Starting single-coin mode for {coin}")
+            logging.info(f"Decision mode: {decision_mode}")
 
             # Test connection and display information
             test_connection(helper, coin)
 
             # Start trading algorithm for single coin
-            run_trailing_stop_strategy(helper, coin, buy_amount)
+            run_trailing_stop_strategy(
+                helper, coin, buy_amount,
+                decision_mode=decision_mode,
+                ai_client=ai_client
+            )
 
         else:
             # Whitelist mode
             logging.info(f"Starting whitelist mode with {len(coin_whitelist)} coins: {', '.join(coin_whitelist)}")
+            logging.info(f"Decision mode: {decision_mode}")
 
             # Test connection with first coin from whitelist
             test_connection(helper, coin_whitelist[0])
 
             # Start trading algorithm for whitelist
-            run_trailing_stop_strategy_whitelist(helper, coin_whitelist, buy_amount)
+            run_trailing_stop_strategy_whitelist(
+                helper, coin_whitelist, buy_amount,
+                decision_mode=decision_mode,
+                ai_client=ai_client
+            )
 
     except exceptions.InvalidRequestError as e:
         logging.error(f"ByBit request error | {e.status_code} | {e.message}")

--- a/bot_test.py
+++ b/bot_test.py
@@ -11,7 +11,7 @@ from dotenv import load_dotenv
 from pybit.unified_trading import HTTP
 from helpers import BybitHelper
 from logger import setup_logger
-from tests import test_connection, test_place_order
+from tests import test_connection
 
 load_dotenv()
 

--- a/helpers.py
+++ b/helpers.py
@@ -53,20 +53,17 @@ class BybitHelper:
             raise ValueError("HTTP client not initialized")
 
         response = self.client.get_wallet_balance(accountType="UNIFIED")
-        
+
         # Handle different response formats from the API
         if isinstance(response, tuple):
             if len(response) == 3:
-                r, _, h = response
+                r, _, _ = response
             elif len(response) == 2:
                 r, _ = response
-                h = None
             else:
                 r = response[0]
-                h = None
         else:
             r = response
-            h = None
 
         r = r.get("result", {}).get("list", [])[0]
 
@@ -96,20 +93,17 @@ class BybitHelper:
             raise ValueError("HTTP client not initialized")
 
         response = self.client.get_transaction_log()
-        
+
         # Handle different response formats from the API
         if isinstance(response, tuple):
             if len(response) == 3:
-                r, _, h = response
+                r, _, _ = response
             elif len(response) == 2:
                 r, _ = response
-                h = None
             else:
                 r = response[0]
-                h = None
         else:
             r = response
-            h = None
 
         df = DataFrame(
             [
@@ -151,23 +145,20 @@ class BybitHelper:
             raise ValueError("Coin name not specified")
 
         try:
-            # API может возвращать разные форматы ответа
+            # API can return different response formats
             api_result = self.client.get_wallet_balance(accountType="UNIFIED")
-            
-            # Обработка различных форматов ответа API
+
+            # Handle different API response formats
             if isinstance(api_result, tuple):
                 if len(api_result) == 3:
-                    response, _, headers = api_result
+                    response, _, _ = api_result
                 elif len(api_result) == 2:
                     response, _ = api_result
-                    headers = None
                 else:
                     response = api_result[0]
-                    headers = None
             else:
                 response = api_result
-                headers = None
-                
+
             if not response:
                 raise RuntimeError("Empty response from API")
 
@@ -186,7 +177,7 @@ class BybitHelper:
             for asset in coins_data:
                 coin_name = asset.get("coin")
                 available_amount = asset.get("availableToWithdraw", "0.0")
-                
+
                 # Check if coin name exists and amount is not empty
                 if coin_name and available_amount and available_amount.strip():
                     try:
@@ -196,16 +187,13 @@ class BybitHelper:
                 elif coin_name:
                     balances[coin_name] = 0.0
 
-            # Log API limits
-            # self.log_limits(headers)
-
             # Return balance for requested coin or 0.0 if coin not found
             return self.round_down(balances.get(coin, 0.0), 3)
 
         except (KeyError, IndexError) as e:
-            raise RuntimeError(f"Unexpected API response format: {str(e)}")
+            raise RuntimeError(f"Unexpected API response format: {str(e)}") from e
         except ValueError as e:
-            raise RuntimeError(f"Value conversion error: {str(e)}")
+            raise RuntimeError(f"Value conversion error: {str(e)}") from e
 
     def get_wallet_balance(self, coin: str) -> float:
         """
@@ -227,23 +215,20 @@ class BybitHelper:
             raise ValueError("Coin name not specified")
 
         try:
-            # API может возвращать разные форматы ответа
+            # API can return different response formats
             api_result = self.client.get_wallet_balance(accountType="UNIFIED")
-            
-            # Обработка различных форматов ответа API
+
+            # Handle different API response formats
             if isinstance(api_result, tuple):
                 if len(api_result) == 3:
-                    response, _, headers = api_result
+                    response, _, _ = api_result
                 elif len(api_result) == 2:
                     response, _ = api_result
-                    headers = None
                 else:
                     response = api_result[0]
-                    headers = None
             else:
                 response = api_result
-                headers = None
-                
+
             if not response:
                 raise RuntimeError("Empty response from API")
 
@@ -262,7 +247,7 @@ class BybitHelper:
             for asset in coins_data:
                 coin_name = asset.get("coin")
                 wallet_balance = asset.get("walletBalance", "0.0")
-                
+
                 # Check if coin name exists and amount is not empty
                 if coin_name and wallet_balance and wallet_balance.strip():
                     try:
@@ -276,9 +261,9 @@ class BybitHelper:
             return self.round_down(balances.get(coin, 0.0), 6)
 
         except (KeyError, IndexError) as e:
-            raise RuntimeError(f"Unexpected API response format: {str(e)}")
+            raise RuntimeError(f"Unexpected API response format: {str(e)}") from e
         except ValueError as e:
-            raise RuntimeError(f"Value conversion error: {str(e)}")
+            raise RuntimeError(f"Value conversion error: {str(e)}") from e
 
     def place_order(
         self,
@@ -321,7 +306,7 @@ class BybitHelper:
             api_result = self.client.get_instruments_info(
                 category=category, symbol=symbol
             )
-            
+
             # Handle different response formats from the API
             if isinstance(api_result, tuple):
                 if len(api_result) == 3:
@@ -362,26 +347,22 @@ class BybitHelper:
                 qty=qty,
                 marketUnit=market_unit,
             )
-            
+
             # Handle different response formats from the API
             if isinstance(api_result, tuple):
                 if len(api_result) == 3:
-                    response, _, headers = api_result
+                    response, _, _ = api_result
                 elif len(api_result) == 2:
                     response, _ = api_result
-                    headers = None
                 else:
                     response = api_result[0]
-                    headers = None
             else:
                 response = api_result
-                headers = None
 
-            # self.log_limits(headers)
             return response
 
         except Exception as e:
-            raise RuntimeError(f"Order placement failed: {str(e)}")
+            raise RuntimeError(f"Order placement failed: {str(e)}") from e
 
     def get_instrument_info(self, category: str, symbol: str) -> dict:
         """
@@ -403,27 +384,24 @@ class BybitHelper:
 
         try:
             api_result = self.client.get_instruments_info(
-                category=category,
-                symbol=symbol
+                category=category, symbol=symbol
             )
-            
+
             # Handle different response formats from the API
             if isinstance(api_result, tuple):
                 if len(api_result) == 3:
-                    response, _, headers = api_result
+                    response, _, _ = api_result
                 elif len(api_result) == 2:
                     response, _ = api_result
-                    headers = None
                 else:
                     response = api_result[0]
-                    headers = None
             else:
                 response = api_result
-                headers = None
-            # self.log_limits(headers)
             return response
         except Exception as e:
-            raise RuntimeError(f"Instrument information retrieval failed: {str(e)}")
+            raise RuntimeError(
+                f"Instrument information retrieval failed: {str(e)}"
+            ) from e
 
     def get_price(self, category: str, symbol: str) -> float:
         """
@@ -440,21 +418,17 @@ class BybitHelper:
             raise ValueError("HTTP client not initialized")
 
         api_result = self.client.get_tickers(category=category, symbol=symbol)
-        
+
         # Handle different response formats from the API
         if isinstance(api_result, tuple):
             if len(api_result) == 3:
-                r, _, h = api_result
+                r, _, _ = api_result
             elif len(api_result) == 2:
                 r, _ = api_result
-                h = None
             else:
                 r = api_result[0]
-                h = None
         else:
             r = api_result
-            h = None
-        # self.log_limits(h)
 
         return float(r.get("result", {}).get("list", [{}])[0].get("lastPrice", "0"))
 
@@ -485,21 +459,17 @@ class BybitHelper:
             interval=interval,
             limit=limit,
         )
-        
+
         # Handle different response formats from the API
         if isinstance(api_result, tuple):
             if len(api_result) == 3:
-                r, _, h = api_result
+                r, _, _ = api_result
             elif len(api_result) == 2:
                 r, _ = api_result
-                h = None
             else:
                 r = api_result[0]
-                h = None
         else:
             r = api_result
-            h = None
-        # self.log_limits(h)
 
         # Get price from hours ago
         old_price = float(r.get("result", {}).get("list", [[0]])[0][1])  # Open price
@@ -529,10 +499,9 @@ class BybitHelper:
 
         try:
             api_result = self.client.get_instruments_info(
-                category=category,
-                symbol=symbol
+                category=category, symbol=symbol
             )
-            
+
             # Handle different response formats from the API
             if isinstance(api_result, tuple):
                 if len(api_result) == 3:
@@ -549,21 +518,21 @@ class BybitHelper:
 
             instrument = response.get("result", {}).get("list", [])[0]
             lot_size_filter = instrument.get("lotSizeFilter", {})
-            
+
             # Get basePrecision - this tells us how many decimal places are allowed
             base_precision = lot_size_filter.get("basePrecision", "0.01")
-            
+
             # Convert precision string to number of decimals
             # e.g., "0.01" -> 2, "0.0001" -> 4, "1" -> 0
             if "." in base_precision:
                 decimals = len(base_precision.split(".")[1])
             else:
                 decimals = 0
-                
+
             return decimals
 
         except Exception as e:
-            raise RuntimeError(f"Failed to get base precision: {str(e)}")
+            raise RuntimeError(f"Failed to get base precision: {str(e)}") from e
 
     def round_down(self, value: float, decimals: int) -> float:
         """

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,9 @@ python-dotenv==1.0.0
 pybit==5.5.0
 pandas>=2.0.0
 
+# AI integration (Anthropic Claude)
+anthropic>=0.40.0
+
 # Additional dependencies that may be needed
 # (uncomment if you encounter import errors)
 # numpy>=1.24.0

--- a/strategies.py
+++ b/strategies.py
@@ -8,91 +8,104 @@ that can be used with the Bybit API.
 import logging
 import random
 import time
-from datetime import datetime
 from concurrent.futures import ThreadPoolExecutor, as_completed
+from datetime import datetime
+from typing import Optional, Tuple
 
+from ai_client import AIClient, AIError
 from helpers import BybitHelper
 
 
 def format_price(price: float | None) -> str:
     """
     Format price to show appropriate number of decimal places
-    
+
     Args:
         price: price value to format
-        
+
     Returns:
         formatted price string
     """
     if price is None or price == 0:
         return "0.0000"
-    
+
     # For very small prices, show up to 12 decimal places
     if price < 0.0001:
-        formatted = f"{price:.12f}".rstrip('0').rstrip('.')
+        formatted = f"{price:.12f}".rstrip("0").rstrip(".")
         # Ensure at least 4 decimal places for consistency
-        if '.' in formatted and len(formatted.split('.')[1]) < 4:
+        if "." in formatted and len(formatted.split(".")[1]) < 4:
             return f"{price:.4f}"
         return formatted
     else:
         return f"{price:.4f}"
 
 
-def check_minimum_order_size(helper: BybitHelper, symbol: str, buy_amount: float) -> bool:
+def check_minimum_order_size(
+    helper: BybitHelper, symbol: str, buy_amount: float
+) -> bool:
     """
     Check if the order meets minimum size requirements
-    
+
     Args:
         helper: BybitHelper instance
         symbol: trading symbol (e.g., "WENUSDT")
         buy_amount: amount in USDT to buy
-        
+
     Returns:
         True if order size is valid, False otherwise
     """
     try:
         # Get instrument info to check minimum order requirements
-        instruments_info = helper.get_instrument_info(
-            category="spot",
-            symbol=symbol
-        )
-        
+        instruments_info = helper.get_instrument_info(category="spot", symbol=symbol)
+
         if instruments_info["retCode"] != 0:
-            logging.error(f"Failed to get instrument info for {symbol}: {instruments_info['retMsg']}")
+            logging.error(
+                f"Failed to get instrument info for {symbol}: {instruments_info['retMsg']}"
+            )
             return False
-            
+
         if not instruments_info["result"]["list"]:
             logging.error(f"No instrument info found for {symbol}")
             return False
-            
+
         instrument = instruments_info["result"]["list"][0]
-        min_order_amt = float(instrument.get("lotSizeFilter", {}).get("minOrderAmt", "0"))
-        min_order_qty = float(instrument.get("lotSizeFilter", {}).get("minOrderQty", "0"))
-        
+        min_order_amt = float(
+            instrument.get("lotSizeFilter", {}).get("minOrderAmt", "0")
+        )
+        min_order_qty = float(
+            instrument.get("lotSizeFilter", {}).get("minOrderQty", "0")
+        )
+
         # Get current price to calculate minimum USDT required
         current_price = helper.get_price("spot", symbol)
         min_usdt_required = min_order_qty * current_price
-        
+
         logging.info(f"Order validation for {symbol}:")
         logging.info(f"  Current price: {format_price(current_price)} USDT")
         logging.info(f"  Your order amount: {buy_amount} USDT")
         logging.info(f"  Minimum order amount: {min_order_amt} USDT")
         logging.info(f"  Minimum order quantity: {min_order_qty} coins")
-        logging.info(f"  Minimum USDT required for min quantity: {min_usdt_required:.2f} USDT")
-        
+        logging.info(
+            f"  Minimum USDT required for min quantity: {min_usdt_required:.2f} USDT"
+        )
+
         # Check minimum order amount (for quoteCoin orders)
         if min_order_amt > 0 and buy_amount < min_order_amt:
-            logging.error(f"❌ Order amount {buy_amount} USDT is less than minimum required {min_order_amt} USDT")
+            logging.error(
+                f"❌ Order amount {buy_amount} USDT is less than minimum required {min_order_amt} USDT"
+            )
             return False
-            
+
         # Check minimum USDT required for minimum quantity
         if min_usdt_required > buy_amount:
-            logging.error(f"❌ Order amount {buy_amount} USDT is less than minimum required {min_usdt_required:.2f} USDT for minimum quantity")
+            logging.error(
+                f"❌ Order amount {buy_amount} USDT is less than minimum required {min_usdt_required:.2f} USDT for minimum quantity"
+            )
             return False
-            
+
         logging.info("✅ Order size validation passed")
         return True
-        
+
     except Exception as e:
         logging.error(f"Error checking minimum order size for {symbol}: {str(e)}")
         return False
@@ -152,17 +165,220 @@ def safe_place_order(helper: BybitHelper, **kwargs):
     return helper.place_order(**kwargs)
 
 
-def scan_coin_parallel(helper: BybitHelper, coin: str, category: str, hours_period: int, quick_period: int):
+def evaluate_entry(
+    decision_mode: str,
+    ai_client: Optional[AIClient],
+    symbol: str,
+    current_price: float,
+    quick_price_change: float,
+    price_change: float,
+    quick_rise_threshold: float,
+    price_drop_threshold: float,
+) -> Tuple[bool, str]:
+    """
+    Evaluate entry conditions based on the mode.
+
+    Logic for each mode:
+
+    MODE "rules":
+    - Checks if rules are triggered (price change thresholds)
+    - AI is not used
+    - Backward compatible with existing logic
+
+    MODE "ai":
+    - AI makes the decision independently of rules
+    - On AI unavailability — fallback to rules
+    - Requires ai_client != None
+
+    MODE "combined":
+    - Rules are checked first
+    - If rules triggered — AI confirmation is requested
+    - Buy only if AI confirms
+    - On AI unavailability — fallback to rules
+
+    Args:
+        decision_mode: Decision mode ("rules", "ai", "combined")
+        ai_client: AIClient instance (can be None for rules mode)
+        symbol: Trading pair (e.g., "WIFUSDT")
+        current_price: Current price in USDT
+        quick_price_change: Price change over 1 hour (%)
+        price_change: Price change over 3 hours (%)
+        quick_rise_threshold: Quick rise threshold (e.g., 3.0)
+        price_drop_threshold: Price drop threshold (e.g., -3.0)
+
+    Returns:
+        Tuple[bool, str]: (should_buy, decision_source)
+
+        should_buy: True if should buy, False otherwise
+
+        decision_source — string describing the decision source:
+        - "rules" — decision made by rules (rules mode)
+        - "rules_quick_rise" — quick rise triggered (rules mode)
+        - "rules_price_drop" — price drop triggered (rules mode)
+        - "ai" — decision made by AI (ai mode)
+        - "rules+ai" — rules triggered + AI confirmed (combined mode)
+        - "ai_veto" — rules triggered, but AI rejected (combined mode)
+        - "rules (ai_unavailable)" — AI unavailable, fallback to rules
+        - "hold" — no signal triggered
+    """
+    # Check if rules are triggered
+    quick_rise_triggered = quick_price_change >= quick_rise_threshold
+    price_drop_triggered = price_change <= price_drop_threshold
+    rules_triggered = quick_rise_triggered or price_drop_triggered
+
+    # Determine trigger reason for logging
+    trigger_reason = ""
+    if quick_rise_triggered:
+        trigger_reason = (
+            f"quick rise {quick_price_change:.2f}% >= {quick_rise_threshold}%"
+        )
+    elif price_drop_triggered:
+        trigger_reason = f"price drop {price_change:.2f}% <= {price_drop_threshold}%"
+
+    # ========== MODE: rules ==========
+    if decision_mode == "rules":
+        if rules_triggered:
+            source = "rules_quick_rise" if quick_rise_triggered else "rules_price_drop"
+            logging.info(f"[rules] Entry signal: {trigger_reason}")
+            return True, source
+        return False, "hold"
+
+    # ========== MODE: ai ==========
+    if decision_mode == "ai":
+        if ai_client is None:
+            logging.error(
+                "AI client is None in 'ai' mode. "
+                "This should not happen - check initialization."
+            )
+            # Fallback to rules as last resort
+            if rules_triggered:
+                logging.warning("Falling back to rules due to missing AI client")
+                return True, "rules (ai_unavailable)"
+            return False, "hold"
+
+        try:
+            # Call AI to make decision
+            logging.debug(f"[ai] Requesting AI decision for {symbol} @ {current_price}")
+
+            ai_decision = ai_client.should_buy(
+                symbol=symbol,
+                current_price=current_price,
+                change_1h=quick_price_change,
+                change_3h=price_change,
+            )
+
+            if ai_decision.should_buy:
+                logging.info(
+                    f"[ai] AI decided to BUY {symbol}: {ai_decision.reasoning}"
+                )
+                return True, "ai"
+            else:
+                logging.info(
+                    f"[ai] AI decided to HOLD {symbol}: {ai_decision.reasoning}"
+                )
+                return False, "hold"
+
+        except AIError as e:
+            # AI error — fallback to rules
+            logging.warning(f"[ai] AI unavailable, falling back to rules: {e}")
+            if rules_triggered:
+                logging.info(f"[ai] Rules triggered ({trigger_reason}), buying")
+                return True, "rules (ai_unavailable)"
+            return False, "hold"
+
+    # ========== MODE: combined ==========
+    if decision_mode == "combined":
+        # Check rules first
+        if not rules_triggered:
+            # Rules not triggered — don't request AI
+            return False, "hold"
+
+        logging.info(f"[combined] Rules triggered: {trigger_reason}")
+
+        # Rules triggered — request AI confirmation
+        if ai_client is None:
+            logging.warning("[combined] AI client is None, using rules only")
+            return True, "rules (ai_unavailable)"
+
+        try:
+            logging.debug(
+                f"[combined] Requesting AI confirmation for {symbol} @ {current_price}"
+            )
+
+            ai_decision = ai_client.should_buy(
+                symbol=symbol,
+                current_price=current_price,
+                change_1h=quick_price_change,
+                change_3h=price_change,
+            )
+
+            if ai_decision.should_buy:
+                logging.info(
+                    f"[combined] AI CONFIRMED buy signal: {ai_decision.reasoning}"
+                )
+                return True, "rules+ai"
+            else:
+                logging.info(
+                    f"[combined] AI VETOED buy signal: {ai_decision.reasoning}"
+                )
+                return False, "ai_veto"
+
+        except AIError as e:
+            # On AI error in combined — fallback to rules
+            logging.warning(f"[combined] AI unavailable, using rules: {e}")
+            return True, "rules (ai_unavailable)"
+
+    # Unknown mode — safe behavior
+    logging.error(f"Unknown decision_mode: {decision_mode}, treating as 'rules'")
+    if rules_triggered:
+        return True, "rules"
+    return False, "hold"
+
+
+def log_entry_decision(
+    symbol: str,
+    should_buy: bool,
+    decision_source: str,
+    current_price: float,
+    quick_price_change: float,
+    price_change: float,
+) -> None:
+    """
+    Log the entry decision result.
+
+    Args:
+        symbol: Trading pair
+        should_buy: Decision result
+        decision_source: Decision source
+        current_price: Current price
+        quick_price_change: Change over 1 hour
+        price_change: Change over 3 hours
+    """
+    action = "BUY" if should_buy else "HOLD"
+    emoji = "✅" if should_buy else "⏳"
+
+    logging.info(
+        f"{emoji} {symbol} Decision: {action} "
+        f"(source: {decision_source}, "
+        f"price: {format_price(current_price)}, "
+        f"1h: {quick_price_change:+.2f}%, "
+        f"3h: {price_change:+.2f}%)"
+    )
+
+
+def scan_coin_parallel(
+    helper: BybitHelper, coin: str, category: str, hours_period: int, quick_period: int
+):
     """
     Scan a single coin for price data (used for parallel execution)
-    
+
     Args:
         helper: BybitHelper instance
         coin: coin name (e.g., "XRP")
         category: market category
         hours_period: period for long-term price change
         quick_period: period for quick price change
-        
+
     Returns:
         dict: Coin data including price and changes, or None if error
     """
@@ -170,27 +386,29 @@ def scan_coin_parallel(helper: BybitHelper, coin: str, category: str, hours_peri
     try:
         current_price = helper.get_price(category, symbol)
         price_change = helper.get_price_change(category, symbol, hours=hours_period)
-        quick_price_change = helper.get_price_change(category, symbol, hours=quick_period)
-        
+        quick_price_change = helper.get_price_change(
+            category, symbol, hours=quick_period
+        )
+
         return {
-            'coin': coin,
-            'symbol': symbol,
-            'price': current_price,
-            'price_change': price_change,
-            'quick_change': quick_price_change,
-            'success': True
+            "coin": coin,
+            "symbol": symbol,
+            "price": current_price,
+            "price_change": price_change,
+            "quick_change": quick_price_change,
+            "success": True,
         }
     except Exception as e:
-        return {
-            'coin': coin,
-            'symbol': symbol,
-            'error': str(e),
-            'success': False
-        }
+        return {"coin": coin, "symbol": symbol, "error": str(e), "success": False}
 
 
 def run_trailing_stop_strategy(
-    helper: BybitHelper, coin: str, buy_amount: float, check_interval: int = 5
+    helper: BybitHelper,
+    coin: str,
+    buy_amount: float,
+    check_interval: int = 5,
+    decision_mode: str = "rules",
+    ai_client: Optional[AIClient] = None,
 ):
     """
     Trading strategy with trailing stop and dual entry conditions.
@@ -247,6 +465,8 @@ def run_trailing_stop_strategy(
         coin: coin name (e.g., "XRP")
         buy_amount: amount in USDT to buy
         check_interval: price check interval in seconds (default: 5)
+        decision_mode: decision mode - "rules", "ai", or "combined" (default: "rules")
+        ai_client: AIClient instance for AI modes (default: None)
     """
     symbol = f"{coin}USDT"
     category = "spot"
@@ -266,6 +486,9 @@ def run_trailing_stop_strategy(
     trailing_activated = False  # whether trailing stop is activated
 
     logging.info(f"Starting algorithm for {symbol}")
+    logging.info(f"Decision mode: {decision_mode}")
+    if ai_client is not None:
+        logging.info(f"AI client initialized: model={ai_client.model}")
     logging.info(
         f"Position entry conditions:\n"
         f"1) Price drop of {abs(price_drop_threshold)}% over {hours_period} hours\n"
@@ -306,15 +529,34 @@ def run_trailing_stop_strategy(
                     f"over {quick_period}h: {format_price(quick_price_change)}%)"
                 )
 
-                # Check entry conditions
-                if quick_price_change >= quick_rise_threshold:
-                    logging.info(
-                        f"\nQuick rise! Price increased by {format_price(quick_price_change)}% in the last hour. Checking order requirements..."
+                # Evaluate entry conditions using unified function
+                should_buy, decision_source = evaluate_entry(
+                    decision_mode=decision_mode,
+                    ai_client=ai_client,
+                    symbol=symbol,
+                    current_price=current_price,
+                    quick_price_change=quick_price_change,
+                    price_change=price_change,
+                    quick_rise_threshold=quick_rise_threshold,
+                    price_drop_threshold=price_drop_threshold,
+                )
+
+                if should_buy:
+                    # Log the entry signal
+                    log_entry_decision(
+                        symbol=symbol,
+                        should_buy=True,
+                        decision_source=decision_source,
+                        current_price=current_price,
+                        quick_price_change=quick_price_change,
+                        price_change=price_change,
                     )
 
                     # Check minimum order size before placing order
                     if not check_minimum_order_size(helper, symbol, buy_amount):
-                        logging.error(f"Cannot place order for {symbol} - minimum order requirements not met")
+                        logging.error(
+                            f"Cannot place order for {symbol} - minimum order requirements not met"
+                        )
                         time.sleep(check_interval)
                         continue
 
@@ -322,7 +564,9 @@ def run_trailing_stop_strategy(
 
                     # Get wallet balance before buying
                     balance_before = helper.get_wallet_balance(coin)
-                    logging.info(f"Balance before buying: {format_price(balance_before)} {coin}")
+                    logging.info(
+                        f"Balance before buying: {format_price(balance_before)} {coin}"
+                    )
 
                     r = safe_place_order(
                         helper,
@@ -341,66 +585,19 @@ def run_trailing_stop_strategy(
 
                     order_id = r.get("result", {}).get("orderId")
                     logging.info(f"Buy order placed successfully. ID: {order_id}")
+                    logging.info(f"Entry triggered by: {decision_source}")
 
                     # Get wallet balance after buying
                     balance_after = helper.get_wallet_balance(coin)
-                    logging.info(f"Balance after buying: {format_price(balance_after)} {coin}")
-
-                    # Calculate exact amount bought
-                    bought_amount = balance_after - balance_before
-                    logging.info(f"Exact amount bought: {format_price(bought_amount)} {coin}")
-
-                    entry_price = current_price
-                    trailing_price = current_price
-                    position_size = (
-                        bought_amount  # Use actual bought amount instead of calculation
-                    )
-                    trailing_activated = False  # Reset trailing activation
-                    logging.info(f"Entered position at price: {format_price(entry_price)} USDT")
-                    logging.info(f"Position size: {format_price(position_size)} {coin}")
-
-                elif price_change <= price_drop_threshold:
                     logging.info(
-                        f"\nPrice dropped by {abs(price_change):.2f}% over {hours_period} hours. Checking order requirements..."
+                        f"Balance after buying: {format_price(balance_after)} {coin}"
                     )
-
-                    # Check minimum order size before placing order
-                    if not check_minimum_order_size(helper, symbol, buy_amount):
-                        logging.error(f"Cannot place order for {symbol} - minimum order requirements not met")
-                        time.sleep(check_interval)
-                        continue
-
-                    logging.info("Placing buy order...")
-
-                    # Get wallet balance before buying
-                    balance_before = helper.get_wallet_balance(coin)
-                    logging.info(f"Balance before buying: {format_price(balance_before)} {coin}")
-
-                    r = safe_place_order(
-                        helper,
-                        category=category,
-                        symbol=symbol,
-                        side="Buy",
-                        order_type="Market",
-                        qty=buy_amount,
-                        market_unit="quoteCoin",
-                    )
-
-                    if r.get("retCode") != 0:
-                        error_msg = f"\nError placing buy order: {r.get('retMsg')}"
-                        logging.error(error_msg)
-                        raise Exception(f"Order placement error: {r.get('retMsg')}")
-
-                    order_id = r.get("result", {}).get("orderId")
-                    logging.info(f"Buy order placed successfully. ID: {order_id}")
-
-                    # Get wallet balance after buying
-                    balance_after = helper.get_wallet_balance(coin)
-                    logging.info(f"Balance after buying: {format_price(balance_after)} {coin}")
 
                     # Calculate exact amount bought
                     bought_amount = balance_after - balance_before
-                    logging.info(f"Exact amount bought: {format_price(bought_amount)} {coin}")
+                    logging.info(
+                        f"Exact amount bought: {format_price(bought_amount)} {coin}"
+                    )
 
                     entry_price = current_price
                     trailing_price = current_price
@@ -408,10 +605,13 @@ def run_trailing_stop_strategy(
                         bought_amount  # Use actual bought amount instead of calculation
                     )
                     trailing_activated = False  # Reset trailing activation
-                    logging.info(f"Entered position at price: {format_price(entry_price)} USDT")
+                    logging.info(
+                        f"Entered position at price: {format_price(entry_price)} USDT"
+                    )
                     logging.info(f"Position size: {format_price(position_size)} {coin}")
+
                 else:
-                    logging.info(" (Waiting for signal)")
+                    logging.info(f" (Waiting for signal, source: {decision_source})")
             else:
                 # If in position, check trailing or exit conditions
                 price_change_from_trailing = (
@@ -451,7 +651,10 @@ def run_trailing_stop_strategy(
                 )
 
                 # Check if we can activate trailing stop
-                if not trailing_activated and total_change_from_entry >= minimum_profit_threshold:
+                if (
+                    not trailing_activated
+                    and total_change_from_entry >= minimum_profit_threshold
+                ):
                     trailing_activated = True
                     logging.info(
                         f"\n🟢 Minimum profit reached! Profit: {format_price(total_change_from_entry)}% >= {minimum_profit_threshold}%"
@@ -474,12 +677,17 @@ def run_trailing_stop_strategy(
                     )
 
                 # Check exit conditions only if trailing is activated
-                elif trailing_activated and price_change_from_trailing <= trailing_drop_threshold:
+                elif (
+                    trailing_activated
+                    and price_change_from_trailing <= trailing_drop_threshold
+                ):
                     # If price drops below threshold from maximum AND trailing is activated, sell
                     logging.info(
                         f"\n🔴 Price dropped by {abs(price_change_from_trailing):.2f}% from trailing point."
                     )
-                    logging.info(f"Final profit: {format_price(total_change_from_entry)}% (≥ {minimum_profit_threshold}%)")
+                    logging.info(
+                        f"Final profit: {format_price(total_change_from_entry)}% (≥ {minimum_profit_threshold}%)"
+                    )
                     logging.info("Placing sell order.")
 
                     # Use the exact position_size that was calculated after buying
@@ -495,14 +703,20 @@ def run_trailing_stop_strategy(
                     # Get the correct decimal places from API
                     try:
                         decimal_places = helper.get_base_precision(category, symbol)
-                        logging.info(f"Base precision for {symbol}: {decimal_places} decimals")
+                        logging.info(
+                            f"Base precision for {symbol}: {decimal_places} decimals"
+                        )
                     except Exception as e:
-                        logging.warning(f"Failed to get base precision: {str(e)}. Using default 2 decimals")
+                        logging.warning(
+                            f"Failed to get base precision: {str(e)}. Using default 2 decimals"
+                        )
                         decimal_places = 2
 
                     sell_quantity = helper.round_down(position_size, decimal_places)
 
-                    logging.info(f"Position size to sell: {format_price(position_size)} {coin}")
+                    logging.info(
+                        f"Position size to sell: {format_price(position_size)} {coin}"
+                    )
                     logging.info(
                         f"Selling quantity: {format_price(sell_quantity)} {coin} (rounded to {decimal_places} decimals)"
                     )
@@ -525,14 +739,20 @@ def run_trailing_stop_strategy(
                     order_id = r.get("result", {}).get("orderId")
                     logging.info(f"Sell order placed successfully. ID: {order_id}")
 
-                    logging.info(f"Closed position at price: {format_price(current_price)} USDT")
-                    logging.info(f"Final profit: {format_price(total_change_from_entry)}%")
+                    logging.info(
+                        f"Closed position at price: {format_price(current_price)} USDT"
+                    )
+                    logging.info(
+                        f"Final profit: {format_price(total_change_from_entry)}%"
+                    )
                     entry_price = None
                     trailing_price = None
                     position_size = None
                     trailing_activated = False
                 elif not trailing_activated:
-                    logging.info(f" (Need {minimum_profit_threshold - total_change_from_entry:.2f}% more for trailing activation)")
+                    logging.info(
+                        f" (Need {minimum_profit_threshold - total_change_from_entry:.2f}% more for trailing activation)"
+                    )
                 else:
                     logging.info(" (Monitoring price)")
 
@@ -562,11 +782,168 @@ def run_trailing_stop_strategy(
             continue
 
 
+def evaluate_whitelist_candidates(
+    candidates: list,
+    decision_mode: str,
+    ai_client: Optional[AIClient],
+    quick_rise_threshold: float,
+    price_drop_threshold: float,
+) -> Optional[dict]:
+    """
+    Evaluate whitelist candidates and select the best one.
+
+    Logic for each mode:
+
+    MODE "rules":
+    - Returns candidate with highest score
+    - AI is not used
+
+    MODE "ai":
+    - For each candidate with rules signal, calls AI
+    - Returns first one for which AI said "buy"
+    - If AI unavailable — fallback to rules
+
+    MODE "combined":
+    - Selects best by rules (highest score)
+    - Requests AI confirmation
+    - If AI confirmed — returns candidate
+    - If AI rejected — returns None
+    - If AI unavailable — returns candidate (fallback)
+
+    Args:
+        candidates: List of candidates with price data
+        decision_mode: Decision mode
+        ai_client: AI client
+        quick_rise_threshold: Quick rise threshold
+        price_drop_threshold: Price drop threshold
+
+    Returns:
+        Best candidate or None
+    """
+    if not candidates:
+        return None
+
+    # Filter candidates where rules triggered
+    valid_candidates = []
+    for c in candidates:
+        quick_change = c.get("quick_change", 0)
+        long_change = c.get("long_change", 0)
+
+        # Check rules conditions
+        if quick_change >= quick_rise_threshold or long_change <= price_drop_threshold:
+            # Calculate score
+            score = max(abs(quick_change), abs(long_change))
+            c["score"] = score
+            c["trigger"] = (
+                "quick_rise" if quick_change >= quick_rise_threshold else "price_drop"
+            )
+            valid_candidates.append(c)
+
+    if not valid_candidates:
+        return None
+
+    # Sort by score (best first)
+    valid_candidates.sort(key=lambda x: x["score"], reverse=True)
+
+    # ========== MODE: rules ==========
+    if decision_mode == "rules":
+        best = valid_candidates[0]
+        logging.info(f"[rules] Selected {best['symbol']} (score: {best['score']:.2f})")
+        best["decision_source"] = "rules"
+        return best
+
+    # ========== MODE: ai ==========
+    if decision_mode == "ai":
+        if ai_client is None:
+            logging.warning("[ai] No AI client, falling back to rules")
+            best = valid_candidates[0]
+            best["decision_source"] = "rules (ai_unavailable)"
+            return best
+
+        # Try each candidate
+        for candidate in valid_candidates:
+            try:
+                logging.debug(f"[ai] Checking {candidate['symbol']} with AI")
+
+                ai_decision = ai_client.should_buy(
+                    symbol=candidate["symbol"],
+                    current_price=candidate["price"],
+                    change_1h=candidate["quick_change"],
+                    change_3h=candidate["long_change"],
+                )
+
+                if ai_decision.should_buy:
+                    logging.info(
+                        f"[ai] AI approved {candidate['symbol']}: {ai_decision.reasoning}"
+                    )
+                    candidate["decision_source"] = "ai"
+                    return candidate
+                else:
+                    logging.info(
+                        f"[ai] AI rejected {candidate['symbol']}: {ai_decision.reasoning}"
+                    )
+
+            except AIError as e:
+                logging.warning(f"[ai] AI error for {candidate['symbol']}: {e}")
+                continue
+
+        # If AI rejected all — fallback to best by rules
+        logging.warning("[ai] AI rejected all candidates, falling back to rules")
+        best = valid_candidates[0]
+        best["decision_source"] = "rules (ai_unavailable)"
+        return best
+
+    # ========== MODE: combined ==========
+    if decision_mode == "combined":
+        best = valid_candidates[0]
+
+        if ai_client is None:
+            logging.warning("[combined] No AI client, using rules only")
+            best["decision_source"] = "rules (ai_unavailable)"
+            return best
+
+        try:
+            logging.debug(f"[combined] Requesting AI confirmation for {best['symbol']}")
+
+            ai_decision = ai_client.should_buy(
+                symbol=best["symbol"],
+                current_price=best["price"],
+                change_1h=best["quick_change"],
+                change_3h=best["long_change"],
+            )
+
+            if ai_decision.should_buy:
+                logging.info(
+                    f"[combined] AI confirmed {best['symbol']}: {ai_decision.reasoning}"
+                )
+                best["decision_source"] = "rules+ai"
+                return best
+            else:
+                logging.info(
+                    f"[combined] AI vetoed {best['symbol']}: {ai_decision.reasoning}"
+                )
+                return None  # AI rejected — don't buy
+
+        except AIError as e:
+            logging.warning(f"[combined] AI unavailable, using rules: {e}")
+            best["decision_source"] = "rules (ai_unavailable)"
+            return best
+
+    # Unknown mode
+    logging.error(f"Unknown decision_mode: {decision_mode}")
+    best = valid_candidates[0] if valid_candidates else None
+    if best:
+        best["decision_source"] = "rules"
+    return best
+
+
 def run_trailing_stop_strategy_whitelist(
     helper: BybitHelper,
     coin_whitelist: list,
     buy_amount: float,
-    check_interval: int = 5
+    check_interval: int = 5,
+    decision_mode: str = "rules",
+    ai_client: Optional[AIClient] = None,
 ):
     """
     Trading strategy with trailing stop for whitelist of coins.
@@ -596,6 +973,8 @@ def run_trailing_stop_strategy_whitelist(
         coin_whitelist: list of coin names (e.g., ["XRP", "ETH", "BTC"])
         buy_amount: amount in USDT to buy
         check_interval: price check interval in seconds (default: 5 for faster scanning)
+        decision_mode: decision mode - "rules", "ai", or "combined" (default: "rules")
+        ai_client: AIClient instance for AI modes (default: None)
     """
     category = "spot"
 
@@ -619,6 +998,9 @@ def run_trailing_stop_strategy_whitelist(
     trailing_activated = False
 
     logging.info(f"Starting whitelist algorithm for coins: {coin_whitelist}")
+    logging.info(f"Decision mode: {decision_mode}")
+    if ai_client is not None:
+        logging.info(f"AI client initialized: model={ai_client.model}")
     logging.info(f"Buy amount: {buy_amount} USDT")
     logging.info(
         f"Entry conditions:\n"
@@ -643,79 +1025,82 @@ def run_trailing_stop_strategy_whitelist(
                 # WHITELIST SCANNING PHASE
                 logging.info(f"\n[{current_time}] 🔍 Scanning whitelist coins...")
 
-                best_opportunity = None
-                best_score = 0
-
                 # Scan all coins in parallel for faster execution
-                with ThreadPoolExecutor(max_workers=min(len(coin_whitelist), 10)) as executor:
+                with ThreadPoolExecutor(
+                    max_workers=min(len(coin_whitelist), 10)
+                ) as executor:
                     # Submit all scanning tasks
                     future_to_coin = {
-                        executor.submit(scan_coin_parallel, helper, coin, category, hours_period, quick_period): coin
+                        executor.submit(
+                            scan_coin_parallel,
+                            helper,
+                            coin,
+                            category,
+                            hours_period,
+                            quick_period,
+                        ): coin
                         for coin in coin_whitelist
                     }
-                    
+
                     # Collect all results first to ensure complete scan
                     all_results = []
                     for future in as_completed(future_to_coin):
                         result = future.result()
                         all_results.append(result)
-                    
-                    # Process all results after collection is complete
+
+                    # Collect candidates from all results
+                    candidates = []
                     for result in all_results:
-                        if not result['success']:
-                            logging.warning(f"  Error checking {result['symbol']}: {result.get('error', 'Unknown error')}")
+                        if not result["success"]:
+                            logging.warning(
+                                f"  Error checking {result['symbol']}: {result.get('error', 'Unknown error')}"
+                            )
                             continue
-                        
-                        # Extract data from result
-                        coin = result['coin']
-                        symbol = result['symbol']
-                        current_price = result['price']
-                        price_change = result['price_change']
-                        quick_price_change = result['quick_change']
-                        
-                        logging.info(
-                            f"  {symbol}: {format_price(current_price)} USDT "
-                            f"({hours_period}h: {format_price(price_change)}%, {quick_period}h: {format_price(quick_price_change)}%)"
+
+                        candidates.append(
+                            {
+                                "coin": result["coin"],
+                                "symbol": result["symbol"],
+                                "price": result["price"],
+                                "quick_change": result["quick_change"],
+                                "long_change": result["price_change"],
+                            }
                         )
 
-                        # Check entry conditions and calculate priority score
-                        score = 0
-                        reason = ""
+                        # Log coin data
+                        logging.info(
+                            f"  {result['symbol']}: {format_price(result['price'])} USDT "
+                            f"({hours_period}h: {format_price(result['price_change'])}%, "
+                            f"{quick_period}h: {format_price(result['quick_change'])}%)"
+                        )
 
-                        if quick_price_change >= quick_rise_threshold:
-                            score = abs(quick_price_change)  # Higher rise = higher priority
-                            reason = f"Quick rise {format_price(quick_price_change)}%"
-                        elif price_change <= price_drop_threshold:
-                            score = abs(price_change)  # Bigger drop = higher priority
-                            reason = f"Price drop {format_price(price_change)}%"
-
-                        if score > best_score:
-                            best_score = score
-                            best_opportunity = {
-                                'coin': coin,
-                                'symbol': symbol,
-                                'price': current_price,
-                                'reason': reason,
-                                'quick_change': quick_price_change,
-                                'long_change': price_change
-                            }
+                # Evaluate and select best candidate using unified function
+                best_opportunity = evaluate_whitelist_candidates(
+                    candidates=candidates,
+                    decision_mode=decision_mode,
+                    ai_client=ai_client,
+                    quick_rise_threshold=quick_rise_threshold,
+                    price_drop_threshold=price_drop_threshold,
+                )
 
                 # If we found an opportunity, execute it
                 if best_opportunity:
-                    coin = best_opportunity['coin']
-                    symbol = best_opportunity['symbol']
-                    current_price = best_opportunity['price']
-                    reason = best_opportunity['reason']
+                    coin = best_opportunity["coin"]
+                    symbol = best_opportunity["symbol"]
+                    current_price = best_opportunity["price"]
+                    decision_source = best_opportunity.get("decision_source", "rules")
 
                     logging.info("\n🎯 ENTRY SIGNAL FOUND!")
                     logging.info(f"Selected coin: {symbol}")
-                    logging.info(f"Reason: {reason}")
+                    logging.info(f"Decision source: {decision_source}")
                     logging.info(f"Price: {format_price(current_price)} USDT")
                     logging.info("Checking order requirements...")
 
                     # Check minimum order size before placing order
                     if not check_minimum_order_size(helper, symbol, buy_amount):
-                        logging.error(f"Cannot place order for {symbol} - minimum order requirements not met")
+                        logging.error(
+                            f"Cannot place order for {symbol} - minimum order requirements not met"
+                        )
                         logging.info("Continuing whitelist scan...")
                         continue
 
@@ -723,7 +1108,9 @@ def run_trailing_stop_strategy_whitelist(
 
                     # Get wallet balance before buying
                     balance_before = helper.get_wallet_balance(coin)
-                    logging.info(f"Balance before buying: {format_price(balance_before)} {coin}")
+                    logging.info(
+                        f"Balance before buying: {format_price(balance_before)} {coin}"
+                    )
 
                     # Place buy order
                     r = safe_place_order(
@@ -743,14 +1130,19 @@ def run_trailing_stop_strategy_whitelist(
 
                     order_id = r.get("result", {}).get("orderId")
                     logging.info(f"✅ Buy order placed successfully. ID: {order_id}")
+                    logging.info(f"Entry triggered by: {decision_source}")
 
                     # Get wallet balance after buying
                     balance_after = helper.get_wallet_balance(coin)
-                    logging.info(f"Balance after buying: {format_price(balance_after)} {coin}")
+                    logging.info(
+                        f"Balance after buying: {format_price(balance_after)} {coin}"
+                    )
 
                     # Calculate exact amount bought
                     bought_amount = balance_after - balance_before
-                    logging.info(f"Exact amount bought: {format_price(bought_amount)} {coin}")
+                    logging.info(
+                        f"Exact amount bought: {format_price(bought_amount)} {coin}"
+                    )
 
                     # Set position variables
                     current_coin = coin
@@ -772,16 +1164,20 @@ def run_trailing_stop_strategy_whitelist(
 
                 # Get current price and changes
                 current_price = safe_get_price(helper, category, symbol)
-                monitoring_price_change = safe_get_price_change(helper, category, symbol, hours=monitoring_period)
+                monitoring_price_change = safe_get_price_change(
+                    helper, category, symbol, hours=monitoring_period
+                )
 
                 # Calculate position metrics
                 price_change_from_trailing = (
                     ((current_price - trailing_price) / trailing_price) * 100
-                    if trailing_price is not None else 0.0
+                    if trailing_price is not None
+                    else 0.0
                 )
                 total_change_from_entry = (
                     ((current_price - entry_price) / entry_price) * 100
-                    if entry_price is not None else 0.0
+                    if entry_price is not None
+                    else 0.0
                 )
 
                 # Determine status
@@ -805,7 +1201,10 @@ def run_trailing_stop_strategy_whitelist(
                 )
 
                 # Check if we can activate trailing stop
-                if not trailing_activated and total_change_from_entry >= minimum_profit_threshold:
+                if (
+                    not trailing_activated
+                    and total_change_from_entry >= minimum_profit_threshold
+                ):
                     trailing_activated = True
                     logging.info(
                         f"\n🟢 Minimum profit reached! Profit: {format_price(total_change_from_entry)}% >= {minimum_profit_threshold}%"
@@ -822,19 +1221,28 @@ def run_trailing_stop_strategy_whitelist(
                     logging.info(
                         f"Updating trailing point: {format_price(old_trailing)} -> {format_price(trailing_price)} USDT"
                     )
-                    logging.info(f"Total profit from entry: {format_price(total_change_from_entry)}%")
+                    logging.info(
+                        f"Total profit from entry: {format_price(total_change_from_entry)}%"
+                    )
 
                 # Check exit conditions only if trailing is activated
-                elif trailing_activated and price_change_from_trailing <= trailing_drop_threshold:
+                elif (
+                    trailing_activated
+                    and price_change_from_trailing <= trailing_drop_threshold
+                ):
                     logging.info(
                         f"\n🔴 Price dropped by {abs(price_change_from_trailing):.2f}% from trailing point."
                     )
-                    logging.info(f"Final profit: {format_price(total_change_from_entry)}% (≥ {minimum_profit_threshold}%)")
+                    logging.info(
+                        f"Final profit: {format_price(total_change_from_entry)}% (≥ {minimum_profit_threshold}%)"
+                    )
                     logging.info("Placing sell order...")
 
                     # Use the exact position_size that was calculated after buying
                     if position_size is None or position_size <= 0:
-                        logging.error(f"No {current_coin} position available for selling")
+                        logging.error(
+                            f"No {current_coin} position available for selling"
+                        )
                         # Reset position variables since we can't sell
                         current_coin = None
                         entry_price = None
@@ -846,15 +1254,23 @@ def run_trailing_stop_strategy_whitelist(
                     # Get the correct decimal places from API
                     try:
                         decimal_places = helper.get_base_precision(category, symbol)
-                        logging.info(f"Base precision for {symbol}: {decimal_places} decimals")
+                        logging.info(
+                            f"Base precision for {symbol}: {decimal_places} decimals"
+                        )
                     except Exception as e:
-                        logging.warning(f"Failed to get base precision: {str(e)}. Using default 2 decimals")
+                        logging.warning(
+                            f"Failed to get base precision: {str(e)}. Using default 2 decimals"
+                        )
                         decimal_places = 2
 
                     sell_quantity = helper.round_down(position_size, decimal_places)
 
-                    logging.info(f"Position size to sell: {format_price(position_size)} {current_coin}")
-                    logging.info(f"Selling quantity: {format_price(sell_quantity)} {current_coin} (rounded to {decimal_places} decimals)")
+                    logging.info(
+                        f"Position size to sell: {format_price(position_size)} {current_coin}"
+                    )
+                    logging.info(
+                        f"Selling quantity: {format_price(sell_quantity)} {current_coin} (rounded to {decimal_places} decimals)"
+                    )
 
                     # Place sell order
                     r = safe_place_order(
@@ -875,8 +1291,12 @@ def run_trailing_stop_strategy_whitelist(
                     order_id = r.get("result", {}).get("orderId")
                     logging.info(f"✅ Sell order placed successfully. ID: {order_id}")
 
-                    logging.info(f"Closed position at price: {format_price(current_price)} USDT")
-                    logging.info(f"Final profit: {format_price(total_change_from_entry)}%")
+                    logging.info(
+                        f"Closed position at price: {format_price(current_price)} USDT"
+                    )
+                    logging.info(
+                        f"Final profit: {format_price(total_change_from_entry)}%"
+                    )
 
                     # Reset position variables and return to whitelist scanning
                     current_coin = None
@@ -889,7 +1309,9 @@ def run_trailing_stop_strategy_whitelist(
 
                 elif not trailing_activated:
                     needed_profit = minimum_profit_threshold - total_change_from_entry
-                    logging.info(f" (Need {needed_profit:.2f}% more for trailing activation)")
+                    logging.info(
+                        f" (Need {needed_profit:.2f}% more for trailing activation)"
+                    )
                 else:
                     logging.info(" (Monitoring price)")
 
@@ -918,6 +1340,8 @@ def run_trailing_stop_strategy_whitelist(
                 time.sleep(30)
                 continue
 
-            logging.warning(f"Continuing after error. Attempt {consecutive_errors}/{max_consecutive_errors}")
+            logging.warning(
+                f"Continuing after error. Attempt {consecutive_errors}/{max_consecutive_errors}"
+            )
             time.sleep(check_interval * 2)
             continue

--- a/test_ai_client.py
+++ b/test_ai_client.py
@@ -1,0 +1,116 @@
+# test_ai_client.py
+
+import pytest
+from unittest.mock import MagicMock, patch
+from ai_client import AIClient, AIDecision, AIError, AIClientState
+
+
+class TestAIDecision:
+    """Tests for AIDecision dataclass"""
+    
+    def test_should_buy_returns_true_for_buy(self):
+        """should_buy returns True for decision='buy'"""
+        decision = AIDecision(decision="buy", reasoning="test")
+        assert decision.should_buy is True
+    
+    def test_should_buy_returns_false_for_hold(self):
+        """should_buy returns False for decision='hold'"""
+        decision = AIDecision(decision="hold", reasoning="test")
+        assert decision.should_buy is False
+    
+    def test_should_buy_case_insensitive(self):
+        """should_buy is case insensitive"""
+        decision = AIDecision(decision="BUY", reasoning="test")
+        assert decision.should_buy is True
+    
+    def test_raw_response_optional(self):
+        """raw_response is optional"""
+        decision = AIDecision(decision="hold", reasoning="test")
+        assert decision.raw_response is None
+
+
+class TestAIClientState:
+    """Tests for AIClientState dataclass"""
+    
+    def test_default_values(self):
+        """Verify default values"""
+        state = AIClientState()
+        
+        assert state.last_call_time == 0.0
+        assert state.last_price == 0.0
+        assert state.last_symbol == ""
+        assert state.consecutive_errors == 0
+        assert state.current_interval == 60
+
+
+class TestAIClient:
+    """Tests for AIClient class"""
+    
+    def test_initialization(self):
+        """Correct client initialization"""
+        client = AIClient(
+            api_key="sk-ant-test",
+            model="test-model",
+            timeout=60,
+            max_retries=5,
+            check_interval=120
+        )
+        
+        assert client.api_key == "sk-ant-test"
+        assert client.model == "test-model"
+        assert client.timeout == 60
+        assert client.max_retries == 5
+        assert client.default_interval == 120
+    
+    def test_initialization_defaults(self):
+        """Initialization with default values"""
+        client = AIClient(api_key="sk-ant-test")
+        
+        assert client.model == "claude-sonnet-4-20250514"
+        assert client.timeout == 30
+        assert client.max_retries == 3
+        assert client.default_interval == 60
+    
+    @patch('ai_client.anthropic.Anthropic')
+    def test_stub_should_buy_returns_hold(self, mock_anthropic):
+        """should_buy returns hold for corresponding API response"""
+        # Setup mock
+        mock_client = MagicMock()
+        mock_anthropic.return_value = mock_client
+        mock_response = MagicMock()
+        mock_response.content = [MagicMock(text='{"decision": "hold", "reasoning": "Stub response for testing"}')]
+        mock_client.messages.create.return_value = mock_response
+        
+        client = AIClient(api_key="sk-ant-test")
+        
+        decision = client.should_buy(
+            symbol="BTCUSDT",
+            current_price=50000.0,
+            change_1h=5.0,
+            change_3h=-3.0
+        )
+        
+        assert decision.decision == "hold"
+        assert "stub" in decision.reasoning.lower()
+    
+    def test_stub_is_call_needed_returns_true(self):
+        """is_call_needed always returns True for first call"""
+        client = AIClient(api_key="sk-ant-test")
+        
+        result = client.is_call_needed("BTCUSDT", 50000.0)
+        
+        assert result is True
+
+
+class TestAIError:
+    """Tests for AIError exception"""
+    
+    def test_ai_error_is_exception(self):
+        """AIError inherits from Exception"""
+        with pytest.raises(AIError):
+            raise AIError("Test error")
+    
+    def test_ai_error_message(self):
+        """AIError stores message"""
+        error = AIError("Custom error message")
+        assert str(error) == "Custom error message"

--- a/test_ai_client_api.py
+++ b/test_ai_client_api.py
@@ -1,0 +1,978 @@
+"""
+Unit tests for AIClient API integration
+
+Tests the interaction with Anthropic API using mocks.
+"""
+
+import time
+from unittest.mock import MagicMock, patch
+
+import anthropic
+import pytest
+
+from ai_client import AIClient, AIDecision, AIError
+
+
+class TestAIClientShouldBuy:
+    """Tests for should_buy method"""
+
+    @patch("ai_client.anthropic.Anthropic")
+    def test_sends_correct_request(self, mock_anthropic):
+        """Sends correct request to API"""
+        # Setup mock
+        mock_client = MagicMock()
+        mock_anthropic.return_value = mock_client
+        mock_response = MagicMock()
+        mock_response.content = [
+            MagicMock(text='{"decision": "hold", "reasoning": "test"}')
+        ]
+        mock_client.messages.create.return_value = mock_response
+
+        client = AIClient(api_key="sk-ant-test")
+
+        client.should_buy(
+            symbol="BTCUSDT", current_price=50000.0, change_1h=2.5, change_3h=-1.2
+        )
+
+        # Verify call
+        mock_client.messages.create.assert_called_once()
+        call_kwargs = mock_client.messages.create.call_args.kwargs
+
+        assert call_kwargs["model"] == "claude-sonnet-4-20250514"
+        assert call_kwargs["max_tokens"] == 256
+        assert "system" in call_kwargs
+        assert "messages" in call_kwargs
+
+    @patch("ai_client.anthropic.Anthropic")
+    def test_returns_ai_decision(self, mock_anthropic):
+        """Returns AIDecision"""
+        mock_client = MagicMock()
+        mock_anthropic.return_value = mock_client
+        mock_response = MagicMock()
+        mock_response.content = [
+            MagicMock(text='{"decision": "buy", "reasoning": "Good opportunity"}')
+        ]
+        mock_client.messages.create.return_value = mock_response
+
+        client = AIClient(api_key="sk-ant-test")
+
+        decision = client.should_buy(
+            symbol="BTCUSDT", current_price=50000.0, change_1h=5.0, change_3h=-3.5
+        )
+
+        assert isinstance(decision, AIDecision)
+        assert decision.decision == "buy"
+        assert decision.should_buy is True
+        assert "Good opportunity" in decision.reasoning
+
+    @patch("ai_client.anthropic.Anthropic")
+    def test_prompt_contains_data(self, mock_anthropic):
+        """Prompt contains passed data"""
+        mock_client = MagicMock()
+        mock_anthropic.return_value = mock_client
+        mock_response = MagicMock()
+        mock_response.content = [
+            MagicMock(text='{"decision": "hold", "reasoning": "test"}')
+        ]
+        mock_client.messages.create.return_value = mock_response
+
+        client = AIClient(api_key="sk-ant-test")
+
+        client.should_buy(
+            symbol="WIFUSDT", current_price=2.45, change_1h=3.5, change_3h=1.2
+        )
+
+        call_kwargs = mock_client.messages.create.call_args.kwargs
+        messages = call_kwargs["messages"]
+        user_message = messages[0]["content"]
+
+        assert "WIFUSDT" in user_message
+        assert "2.45" in user_message
+        assert "+3.50%" in user_message
+        assert "+1.20%" in user_message
+
+
+class TestAIClientInit:
+    """Tests for client initialization"""
+
+    @patch("ai_client.anthropic.Anthropic")
+    def test_creates_anthropic_client(self, mock_anthropic):
+        """Creates Anthropic client"""
+        AIClient(api_key="sk-ant-test", timeout=60)
+
+        mock_anthropic.assert_called_once_with(api_key="sk-ant-test", timeout=60)
+
+    @patch("ai_client.anthropic.Anthropic")
+    def test_raises_on_init_error(self, mock_anthropic):
+        """Raises AIError on initialization error"""
+        mock_anthropic.side_effect = Exception("Init failed")
+
+        with pytest.raises(AIError) as exc_info:
+            AIClient(api_key="sk-ant-test")
+
+        assert "Failed to initialize" in str(exc_info.value)
+
+
+class TestParseResponse:
+    """Tests for response parsing"""
+
+    @patch("ai_client.anthropic.Anthropic")
+    def test_parses_valid_buy_response(self, mock_anthropic):
+        """Parses valid response with decision=buy"""
+        mock_anthropic.return_value = MagicMock()
+        client = AIClient(api_key="sk-ant-test")
+
+        response = '{"decision": "buy", "reasoning": "Strong momentum detected"}'
+        decision = client._parse_response(response)
+
+        assert decision.decision == "buy"
+        assert decision.should_buy is True
+        assert decision.reasoning == "Strong momentum detected"
+
+    @patch("ai_client.anthropic.Anthropic")
+    def test_parses_valid_hold_response(self, mock_anthropic):
+        """Parses valid response with decision=hold"""
+        mock_anthropic.return_value = MagicMock()
+        client = AIClient(api_key="sk-ant-test")
+
+        response = '{"decision": "hold", "reasoning": "Waiting for better entry"}'
+        decision = client._parse_response(response)
+
+        assert decision.decision == "hold"
+        assert decision.should_buy is False
+        assert decision.reasoning == "Waiting for better entry"
+
+    @patch("ai_client.anthropic.Anthropic")
+    def test_normalizes_decision_case(self, mock_anthropic):
+        """Normalizes decision case"""
+        mock_anthropic.return_value = MagicMock()
+        client = AIClient(api_key="sk-ant-test")
+
+        response = '{"decision": "BUY", "reasoning": "test"}'
+        decision = client._parse_response(response)
+
+        assert decision.decision == "buy"
+        assert decision.should_buy is True
+
+    @patch("ai_client.anthropic.Anthropic")
+    def test_strips_whitespace_from_decision(self, mock_anthropic):
+        """Strips whitespace from decision"""
+        mock_anthropic.return_value = MagicMock()
+        client = AIClient(api_key="sk-ant-test")
+
+        response = '{"decision": "  buy  ", "reasoning": "test"}'
+        decision = client._parse_response(response)
+
+        assert decision.decision == "buy"
+
+    @patch("ai_client.anthropic.Anthropic")
+    def test_handles_missing_reasoning(self, mock_anthropic):
+        """Handles missing reasoning"""
+        mock_anthropic.return_value = MagicMock()
+        client = AIClient(api_key="sk-ant-test")
+
+        response = '{"decision": "hold"}'
+        decision = client._parse_response(response)
+
+        assert decision.decision == "hold"
+        assert decision.reasoning == "No reasoning provided"
+
+    @patch("ai_client.anthropic.Anthropic")
+    def test_handles_empty_reasoning(self, mock_anthropic):
+        """Handles empty reasoning"""
+        mock_anthropic.return_value = MagicMock()
+        client = AIClient(api_key="sk-ant-test")
+
+        response = '{"decision": "hold", "reasoning": ""}'
+        decision = client._parse_response(response)
+
+        assert decision.reasoning == "No reasoning provided"
+
+    @patch("ai_client.anthropic.Anthropic")
+    def test_handles_whitespace_reasoning(self, mock_anthropic):
+        """Handles reasoning with only whitespace"""
+        mock_anthropic.return_value = MagicMock()
+        client = AIClient(api_key="sk-ant-test")
+
+        response = '{"decision": "hold", "reasoning": "   "}'
+        decision = client._parse_response(response)
+
+        assert decision.reasoning == "No reasoning provided"
+
+    @patch("ai_client.anthropic.Anthropic")
+    def test_strips_markdown_json_block(self, mock_anthropic):
+        """Strips markdown code block with json"""
+        mock_anthropic.return_value = MagicMock()
+        client = AIClient(api_key="sk-ant-test")
+
+        response = '```json\n{"decision": "buy", "reasoning": "test"}\n```'
+        decision = client._parse_response(response)
+
+        assert decision.decision == "buy"
+
+    @patch("ai_client.anthropic.Anthropic")
+    def test_strips_markdown_block_without_language(self, mock_anthropic):
+        """Strips markdown code block without language tag"""
+        mock_anthropic.return_value = MagicMock()
+        client = AIClient(api_key="sk-ant-test")
+
+        response = '```\n{"decision": "hold", "reasoning": "test"}\n```'
+        decision = client._parse_response(response)
+
+        assert decision.decision == "hold"
+
+    @patch("ai_client.anthropic.Anthropic")
+    def test_treats_unexpected_decision_as_hold(self, mock_anthropic):
+        """Unexpected decision value is treated as hold"""
+        mock_anthropic.return_value = MagicMock()
+        client = AIClient(api_key="sk-ant-test")
+
+        response = '{"decision": "wait", "reasoning": "test"}'
+        decision = client._parse_response(response)
+
+        assert decision.decision == "hold"
+        assert decision.should_buy is False
+
+    @patch("ai_client.anthropic.Anthropic")
+    def test_treats_sell_as_hold(self, mock_anthropic):
+        """decision=sell is treated as hold"""
+        mock_anthropic.return_value = MagicMock()
+        client = AIClient(api_key="sk-ant-test")
+
+        response = '{"decision": "sell", "reasoning": "test"}'
+        decision = client._parse_response(response)
+
+        assert decision.decision == "hold"
+
+    @patch("ai_client.anthropic.Anthropic")
+    def test_stores_raw_response(self, mock_anthropic):
+        """Stores raw response"""
+        mock_anthropic.return_value = MagicMock()
+        client = AIClient(api_key="sk-ant-test")
+
+        response = '{"decision": "buy", "reasoning": "test"}'
+        decision = client._parse_response(response)
+
+        assert decision.raw_response == response
+
+
+class TestParseResponseErrors:
+    """Tests for parsing error handling"""
+
+    @patch("ai_client.anthropic.Anthropic")
+    def test_raises_on_invalid_json(self, mock_anthropic):
+        """Raises AIError on invalid JSON"""
+        mock_anthropic.return_value = MagicMock()
+        client = AIClient(api_key="sk-ant-test")
+
+        with pytest.raises(AIError) as exc_info:
+            client._parse_response("not valid json")
+
+        assert "Invalid JSON" in str(exc_info.value)
+
+    @patch("ai_client.anthropic.Anthropic")
+    def test_raises_on_json_array(self, mock_anthropic):
+        """Raises AIError if JSON is an array"""
+        mock_anthropic.return_value = MagicMock()
+        client = AIClient(api_key="sk-ant-test")
+
+        with pytest.raises(AIError) as exc_info:
+            client._parse_response('[{"decision": "buy"}]')
+
+        assert "must be a JSON object" in str(exc_info.value)
+
+    @patch("ai_client.anthropic.Anthropic")
+    def test_raises_on_missing_decision_field(self, mock_anthropic):
+        """Raises AIError when decision field is missing"""
+        mock_anthropic.return_value = MagicMock()
+        client = AIClient(api_key="sk-ant-test")
+
+        with pytest.raises(AIError) as exc_info:
+            client._parse_response('{"reasoning": "some text"}')
+
+        assert "Missing 'decision'" in str(exc_info.value)
+
+    @patch("ai_client.anthropic.Anthropic")
+    def test_raises_on_non_string_decision(self, mock_anthropic):
+        """Raises AIError if decision is not a string"""
+        mock_anthropic.return_value = MagicMock()
+        client = AIClient(api_key="sk-ant-test")
+
+        with pytest.raises(AIError) as exc_info:
+            client._parse_response('{"decision": 1, "reasoning": "test"}')
+
+        assert "'decision' must be a string" in str(exc_info.value)
+
+    @patch("ai_client.anthropic.Anthropic")
+    def test_raises_on_null_decision(self, mock_anthropic):
+        """Raises AIError if decision = null"""
+        mock_anthropic.return_value = MagicMock()
+        client = AIClient(api_key="sk-ant-test")
+
+        with pytest.raises(AIError) as exc_info:
+            client._parse_response('{"decision": null, "reasoning": "test"}')
+
+        assert "'decision' must be a string" in str(exc_info.value)
+
+
+class TestExtractJsonFromResponse:
+    """Tests for _extract_json_from_response"""
+
+    @patch("ai_client.anthropic.Anthropic")
+    def test_returns_plain_json_unchanged(self, mock_anthropic):
+        """Returns plain JSON unchanged"""
+        mock_anthropic.return_value = MagicMock()
+        client = AIClient(api_key="sk-ant-test")
+
+        json_str = '{"decision": "buy"}'
+
+        result = client._extract_json_from_response(json_str)
+
+        assert result == json_str
+
+    @patch("ai_client.anthropic.Anthropic")
+    def test_extracts_from_json_code_block(self, mock_anthropic):
+        """Extracts JSON from ```json ... ```"""
+        mock_anthropic.return_value = MagicMock()
+        client = AIClient(api_key="sk-ant-test")
+
+        response = '```json\n{"decision": "buy"}\n```'
+
+        result = client._extract_json_from_response(response)
+
+        assert result == '{"decision": "buy"}'
+
+    @patch("ai_client.anthropic.Anthropic")
+    def test_extracts_from_plain_code_block(self, mock_anthropic):
+        """Extracts JSON from ``` ... ```"""
+        mock_anthropic.return_value = MagicMock()
+        client = AIClient(api_key="sk-ant-test")
+
+        response = '```\n{"decision": "hold"}\n```'
+
+        result = client._extract_json_from_response(response)
+
+        assert result == '{"decision": "hold"}'
+
+    @patch("ai_client.anthropic.Anthropic")
+    def test_handles_extra_whitespace(self, mock_anthropic):
+        """Handles extra whitespace"""
+        mock_anthropic.return_value = MagicMock()
+        client = AIClient(api_key="sk-ant-test")
+
+        response = '  ```json\n  {"decision": "buy"}  \n```  '
+
+        result = client._extract_json_from_response(response.strip())
+
+        assert '{"decision": "buy"}' in result
+
+
+class TestRetryLogic:
+    """Tests for retry logic."""
+
+    @patch("ai_client.anthropic.Anthropic")
+    def test_successful_request_no_retry(self, mock_anthropic):
+        """Successful request does not require retry."""
+        # Setup mock for successful response
+        mock_client = MagicMock()
+        mock_anthropic.return_value = mock_client
+        mock_response = MagicMock()
+        mock_response.content = [
+            MagicMock(text='{"decision": "buy", "reasoning": "test"}')
+        ]
+        mock_client.messages.create.return_value = mock_response
+
+        client = AIClient(api_key="sk-ant-test")
+
+        decision = client.should_buy("BTCUSDT", 50000, -2.5, -3.5)
+
+        assert decision.decision == "buy"
+        assert mock_client.messages.create.call_count == 1
+
+    @patch("ai_client.anthropic.Anthropic")
+    def test_retry_on_rate_limit(self, mock_anthropic):
+        """Retry on rate limit."""
+        # First call — rate limit, second — success
+        mock_client = MagicMock()
+        mock_anthropic.return_value = mock_client
+
+        rate_limit_error = anthropic.RateLimitError(
+            message="Rate limited",
+            response=MagicMock(headers={"retry-after": "1"}),
+            body=None,
+        )
+        mock_response = MagicMock()
+        mock_response.content = [
+            MagicMock(text='{"decision": "hold", "reasoning": "test"}')
+        ]
+
+        mock_client.messages.create.side_effect = [rate_limit_error, mock_response]
+
+        client = AIClient(api_key="sk-ant-test")
+
+        with patch("ai_client.time.sleep") as mock_sleep:
+            decision = client.should_buy("BTCUSDT", 50000, -2.5, -3.5)
+
+        assert decision.decision == "hold"
+        assert mock_client.messages.create.call_count == 2
+        mock_sleep.assert_called_once()
+
+    @patch("ai_client.anthropic.Anthropic")
+    def test_retry_on_api_error(self, mock_anthropic):
+        """Retry on API error (500)."""
+        mock_client = MagicMock()
+        mock_anthropic.return_value = mock_client
+
+        api_error = anthropic.APIStatusError(
+            message="Internal Server Error",
+            response=MagicMock(status_code=500),
+            body=None,
+        )
+        mock_response = MagicMock()
+        mock_response.content = [
+            MagicMock(text='{"decision": "buy", "reasoning": "test"}')
+        ]
+
+        mock_client.messages.create.side_effect = [api_error, mock_response]
+
+        client = AIClient(api_key="sk-ant-test")
+
+        with patch("ai_client.time.sleep"):
+            decision = client.should_buy("BTCUSDT", 50000, -2.5, -3.5)
+
+        assert decision.decision == "buy"
+        assert mock_client.messages.create.call_count == 2
+
+    @patch("ai_client.anthropic.Anthropic")
+    def test_retry_on_connection_error(self, mock_anthropic):
+        """Retry on connection error."""
+        mock_client = MagicMock()
+        mock_anthropic.return_value = mock_client
+
+        connection_error = anthropic.APIConnectionError(
+            message="Connection failed", request=MagicMock()
+        )
+        mock_response = MagicMock()
+        mock_response.content = [
+            MagicMock(text='{"decision": "hold", "reasoning": "test"}')
+        ]
+
+        mock_client.messages.create.side_effect = [connection_error, mock_response]
+
+        client = AIClient(api_key="sk-ant-test")
+
+        with patch("ai_client.time.sleep"):
+            decision = client.should_buy("BTCUSDT", 50000, -2.5, -3.5)
+
+        assert decision.decision == "hold"
+        assert mock_client.messages.create.call_count == 2
+
+    @patch("ai_client.anthropic.Anthropic")
+    def test_raises_after_max_retries(self, mock_anthropic):
+        """Raises AIError after exhausting retries."""
+        mock_client = MagicMock()
+        mock_anthropic.return_value = mock_client
+
+        client = AIClient(api_key="sk-ant-test", max_retries=3)
+
+        api_error = anthropic.APIStatusError(
+            message="Server Error", response=MagicMock(status_code=500), body=None
+        )
+
+        mock_client.messages.create.side_effect = api_error
+
+        with patch("ai_client.time.sleep"):
+            with pytest.raises(AIError) as exc_info:
+                client.should_buy("BTCUSDT", 50000, -2.5, -3.5)
+
+        assert "Failed to get AI decision after 3 attempts" in str(exc_info.value)
+        assert mock_client.messages.create.call_count == 3
+
+    @patch("ai_client.anthropic.Anthropic")
+    def test_no_retry_on_parse_error(self, mock_anthropic):
+        """No retry on parse error."""
+        mock_client = MagicMock()
+        mock_anthropic.return_value = mock_client
+
+        mock_response = MagicMock()
+        mock_response.content = [MagicMock(text="invalid json")]
+        mock_client.messages.create.return_value = mock_response
+
+        client = AIClient(api_key="sk-ant-test")
+
+        with pytest.raises(AIError) as exc_info:
+            client.should_buy("BTCUSDT", 50000, -2.5, -3.5)
+
+        assert "Invalid JSON" in str(exc_info.value)
+        # Only one call, no retry
+        assert mock_client.messages.create.call_count == 1
+
+
+class TestExponentialBackoff:
+    """Tests for exponential backoff."""
+
+    @patch("ai_client.anthropic.Anthropic")
+    def test_backoff_delay_increases(self, mock_anthropic):
+        """Delay increases exponentially."""
+        mock_anthropic.return_value = MagicMock()
+        client = AIClient(api_key="sk-ant-test")
+
+        assert client._calculate_backoff_delay(0) == 2.0
+        assert client._calculate_backoff_delay(1) == 4.0
+        assert client._calculate_backoff_delay(2) == 8.0
+        assert client._calculate_backoff_delay(3) == 16.0
+        assert client._calculate_backoff_delay(4) == 32.0
+
+    @patch("ai_client.anthropic.Anthropic")
+    def test_backoff_delay_max_limit(self, mock_anthropic):
+        """Delay does not exceed max_delay."""
+        mock_anthropic.return_value = MagicMock()
+        client = AIClient(api_key="sk-ant-test")
+        client.max_delay = 60.0
+
+        assert client._calculate_backoff_delay(10) == 60.0
+        assert client._calculate_backoff_delay(100) == 60.0
+
+
+class TestRateLimitHandling:
+    """Tests for rate limit handling."""
+
+    @patch("ai_client.anthropic.Anthropic")
+    def test_uses_retry_after_header(self, mock_anthropic):
+        """Uses value from retry-after header."""
+        mock_anthropic.return_value = MagicMock()
+        client = AIClient(api_key="sk-ant-test")
+
+        wait_time = client._handle_rate_limit(retry_after=30)
+
+        assert wait_time == 30.0
+
+    @patch("ai_client.anthropic.Anthropic")
+    def test_uses_exponential_backoff_without_header(self, mock_anthropic):
+        """Uses exponential backoff without header."""
+        mock_anthropic.return_value = MagicMock()
+        client = AIClient(api_key="sk-ant-test")
+        client.state.consecutive_errors = 2
+
+        wait_time = client._handle_rate_limit(retry_after=None)
+
+        # base_delay * 2^consecutive_errors = 2 * 2^2 = 8
+        assert wait_time == 8.0
+
+    @patch("ai_client.anthropic.Anthropic")
+    def test_increases_check_interval(self, mock_anthropic):
+        """Increases check interval on rate limit."""
+        mock_anthropic.return_value = MagicMock()
+        client = AIClient(api_key="sk-ant-test")
+        initial_interval = client.state.current_interval
+
+        client._handle_rate_limit(retry_after=10)
+
+        assert client.state.current_interval == initial_interval * 2
+
+    @patch("ai_client.anthropic.Anthropic")
+    def test_check_interval_max_limit(self, mock_anthropic):
+        """Interval does not exceed 5 minutes."""
+        mock_anthropic.return_value = MagicMock()
+        client = AIClient(api_key="sk-ant-test")
+        client.state.current_interval = 200
+
+        client._handle_rate_limit(retry_after=10)
+
+        assert client.state.current_interval == 300  # 5 minutes maximum
+
+
+class TestStateManagement:
+    """Tests for state management."""
+
+    @patch("ai_client.anthropic.Anthropic")
+    def test_update_state_on_success(self, mock_anthropic):
+        """Updates state on success."""
+        mock_client = MagicMock()
+        mock_anthropic.return_value = mock_client
+
+        mock_response = MagicMock()
+        mock_response.content = [
+            MagicMock(text='{"decision": "buy", "reasoning": "test"}')
+        ]
+        mock_client.messages.create.return_value = mock_response
+
+        client = AIClient(api_key="sk-ant-test")
+        client.state.consecutive_errors = 5
+        client.state.current_interval = 120
+
+        client.should_buy("BTCUSDT", 50000, -2.5, -3.5)
+
+        assert client.state.consecutive_errors == 0
+        assert client.state.last_symbol == "BTCUSDT"
+        assert client.state.last_price == 50000
+        assert client.state.current_interval == client.default_interval
+
+    @patch("ai_client.anthropic.Anthropic")
+    def test_increments_errors_on_failure(self, mock_anthropic):
+        """Increments error counter on failure."""
+        mock_client = MagicMock()
+        mock_anthropic.return_value = mock_client
+
+        client = AIClient(api_key="sk-ant-test", max_retries=2)
+
+        api_error = anthropic.APIStatusError(
+            message="Error", response=MagicMock(status_code=500), body=None
+        )
+        mock_client.messages.create.side_effect = api_error
+
+        initial_errors = client.state.consecutive_errors
+
+        with patch("ai_client.time.sleep"):
+            with pytest.raises(AIError):
+                client.should_buy("BTCUSDT", 50000, -2.5, -3.5)
+
+        assert client.state.consecutive_errors == initial_errors + 2
+
+
+class TestExtractRetryAfter:
+    """Tests for extracting retry-after."""
+
+    @patch("ai_client.anthropic.Anthropic")
+    def test_extracts_from_header(self, mock_anthropic):
+        """Extracts value from header."""
+        mock_anthropic.return_value = MagicMock()
+        client = AIClient(api_key="sk-ant-test")
+
+        error = MagicMock()
+        error.response = MagicMock()
+        error.response.headers = {"retry-after": "45"}
+
+        result = client._extract_retry_after(error)
+
+        assert result == 45
+
+    @patch("ai_client.anthropic.Anthropic")
+    def test_returns_none_without_header(self, mock_anthropic):
+        """Returns None without header."""
+        mock_anthropic.return_value = MagicMock()
+        client = AIClient(api_key="sk-ant-test")
+
+        error = MagicMock()
+        error.response = MagicMock()
+        error.response.headers = {}
+
+        result = client._extract_retry_after(error)
+
+        assert result is None
+
+    @patch("ai_client.anthropic.Anthropic")
+    def test_returns_none_on_invalid_value(self, mock_anthropic):
+        """Returns None on invalid value."""
+        mock_anthropic.return_value = MagicMock()
+        client = AIClient(api_key="sk-ant-test")
+
+        error = MagicMock()
+        error.response = MagicMock()
+        error.response.headers = {"retry-after": "invalid"}
+
+        result = client._extract_retry_after(error)
+
+        assert result is None
+
+    @patch("ai_client.anthropic.Anthropic")
+    def test_returns_none_without_response(self, mock_anthropic):
+        """Returns None without response."""
+        mock_anthropic.return_value = MagicMock()
+        client = AIClient(api_key="sk-ant-test")
+
+        error = MagicMock()
+        error.response = None
+
+        result = client._extract_retry_after(error)
+
+        assert result is None
+
+
+class TestIsCallNeeded:
+    """Tests for is_call_needed."""
+
+    @patch("ai_client.anthropic.Anthropic")
+    def test_first_call_always_needed(self, mock_anthropic):
+        """First call is always needed."""
+        client = AIClient(api_key="sk-ant-test", check_interval=60)
+        assert client.is_call_needed("BTCUSDT", 50000) is True
+
+    @patch("ai_client.anthropic.Anthropic")
+    def test_call_needed_when_symbol_changes(self, mock_anthropic):
+        """Call needed when symbol changes."""
+        # Simulate previous call
+        client = AIClient(api_key="sk-ant-test", check_interval=60)
+        client.state.last_call_time = time.time()
+        client.state.last_symbol = "BTCUSDT"
+        client.state.last_price = 50000
+
+        assert client.is_call_needed("ETHUSDT", 3000) is True
+
+    @patch("ai_client.anthropic.Anthropic")
+    def test_call_not_needed_within_interval(self, mock_anthropic):
+        """Call not needed within interval."""
+        client = AIClient(api_key="sk-ant-test", check_interval=60)
+        client.state.last_call_time = time.time()
+        client.state.last_symbol = "BTCUSDT"
+        client.state.last_price = 50000
+        client.state.current_interval = 60
+
+        assert client.is_call_needed("BTCUSDT", 50100) is False
+
+    @patch("ai_client.anthropic.Anthropic")
+    def test_call_not_needed_small_price_change(self, mock_anthropic):
+        """Call not needed for small price change."""
+        # Interval elapsed
+        client = AIClient(api_key="sk-ant-test", check_interval=60)
+        client.state.last_call_time = time.time() - 120
+        client.state.last_symbol = "BTCUSDT"
+        client.state.last_price = 50000
+        client.state.current_interval = 60
+        client.price_change_threshold = 0.5
+
+        # Change 0.1% < 0.5%
+        new_price = 50000 * 1.001  # 50050
+        assert client.is_call_needed("BTCUSDT", new_price) is False
+
+    @patch("ai_client.anthropic.Anthropic")
+    def test_call_needed_significant_price_change(self, mock_anthropic):
+        """Call needed for significant price change."""
+        # Interval elapsed
+        client = AIClient(api_key="sk-ant-test", check_interval=60)
+        client.state.last_call_time = time.time() - 120
+        client.state.last_symbol = "BTCUSDT"
+        client.state.last_price = 50000
+        client.state.current_interval = 60
+        client.price_change_threshold = 0.5
+
+        # Change 1% > 0.5%
+        new_price = 50000 * 1.01  # 50500
+        assert client.is_call_needed("BTCUSDT", new_price) is True
+
+    @patch("ai_client.anthropic.Anthropic")
+    def test_call_needed_after_interval_elapsed(self, mock_anthropic):
+        """Call needed after interval elapsed with significant price change."""
+        client = AIClient(api_key="sk-ant-test", check_interval=60)
+        client.state.last_call_time = time.time() - 120
+        client.state.last_symbol = "BTCUSDT"
+        client.state.last_price = 50000
+        client.state.current_interval = 60
+
+        # Price changed significantly
+        assert client.is_call_needed("BTCUSDT", 52000) is True
+
+
+class TestCaching:
+    """Tests for decision caching."""
+
+    @patch("ai_client.anthropic.Anthropic")
+    def test_caches_decision(self, mock_anthropic):
+        """Caches decision after call."""
+        mock_client = MagicMock()
+        mock_anthropic.return_value = mock_client
+        mock_response = MagicMock()
+        mock_response.content = [
+            MagicMock(text='{"decision": "buy", "reasoning": "test"}')
+        ]
+        mock_client.messages.create.return_value = mock_response
+
+        client = AIClient(api_key="sk-ant-test", check_interval=60)
+        client.should_buy("BTCUSDT", 50000, -2.5, -3.5)
+
+        assert client._last_decision is not None
+        assert client._last_decision.decision == "buy"
+
+    @patch("ai_client.anthropic.Anthropic")
+    def test_returns_cached_decision_when_not_needed(self, mock_anthropic):
+        """Returns cached decision when call is not needed."""
+        # First make real call
+        mock_client = MagicMock()
+        mock_anthropic.return_value = mock_client
+        mock_response = MagicMock()
+        mock_response.content = [
+            MagicMock(text='{"decision": "buy", "reasoning": "test"}')
+        ]
+        mock_client.messages.create.return_value = mock_response
+
+        client = AIClient(api_key="sk-ant-test", check_interval=60)
+        client.should_buy("BTCUSDT", 50000, -2.5, -3.5)
+
+        # Reset call counter
+        mock_client.messages.create.reset_mock()
+
+        # Simulate elapsed interval but small price change
+        client.state.last_call_time = time.time() - 120  # Interval elapsed
+        # Price change 0.1% < 0.5% threshold
+        new_price = 50000 * 1.001  # 50050
+
+        # Second call with small price change
+        # Should return cache without API call
+        decision = client.should_buy("BTCUSDT", new_price, -2.5, -3.5)
+
+        assert decision.decision == "buy"
+        mock_client.messages.create.assert_not_called()
+
+    @patch("ai_client.anthropic.Anthropic")
+    def test_force_ignores_cache(self, mock_anthropic):
+        """Force parameter ignores cache."""
+        # Cache decision
+        mock_client = MagicMock()
+        mock_anthropic.return_value = mock_client
+        mock_response = MagicMock()
+        mock_response.content = [
+            MagicMock(text='{"decision": "hold", "reasoning": "cached"}')
+        ]
+        mock_client.messages.create.return_value = mock_response
+
+        client = AIClient(api_key="sk-ant-test", check_interval=60)
+        client._last_decision = AIDecision("hold", "cached")
+        client.state.last_call_time = time.time()
+        client.state.last_symbol = "BTCUSDT"
+        client.state.last_price = 50000
+
+        mock_response2 = MagicMock()
+        mock_response2.content = [
+            MagicMock(text='{"decision": "buy", "reasoning": "forced"}')
+        ]
+        mock_client.messages.create.return_value = mock_response2
+
+        decision = client.should_buy("BTCUSDT", 50000, -2.5, -3.5, force=True)
+
+        assert decision.decision == "buy"
+        assert decision.reasoning == "forced"
+        mock_client.messages.create.assert_called_once()
+
+    @patch("ai_client.anthropic.Anthropic")
+    def test_get_cached_decision_returns_last(self, mock_anthropic):
+        """get_cached_decision returns last decision."""
+        client = AIClient(api_key="sk-ant-test", check_interval=60)
+        client._last_decision = AIDecision("hold", "test reason")
+
+        cached = client.get_cached_decision()
+
+        assert cached is not None
+        assert cached.decision == "hold"
+        assert cached.reasoning == "test reason"
+
+    @patch("ai_client.anthropic.Anthropic")
+    def test_get_cached_decision_returns_none_when_empty(self, mock_anthropic):
+        """get_cached_decision returns None when cache is empty."""
+        client = AIClient(api_key="sk-ant-test", check_interval=60)
+        cached = client.get_cached_decision()
+
+        assert cached is None
+
+
+class TestResetCache:
+    """Tests for cache reset."""
+
+    @patch("ai_client.anthropic.Anthropic")
+    def test_reset_clears_state(self, mock_anthropic):
+        """reset_cache clears state."""
+        client = AIClient(api_key="sk-ant-test", check_interval=60)
+        client.state.last_call_time = time.time()
+        client.state.last_symbol = "BTCUSDT"
+        client.state.last_price = 50000
+        client.state.consecutive_errors = 5
+        client._last_decision = AIDecision("buy", "test")
+
+        client.reset_cache()
+
+        assert client.state.last_call_time == 0.0
+        assert client.state.last_symbol == ""
+        assert client.state.last_price == 0.0
+        assert client.state.consecutive_errors == 0
+        assert client._last_decision is None
+
+    @patch("ai_client.anthropic.Anthropic")
+    def test_reset_restores_default_interval(self, mock_anthropic):
+        """reset_cache restores default interval."""
+        client = AIClient(api_key="sk-ant-test", check_interval=60)
+        client.state.current_interval = 300  # Increased due to rate limit
+
+        client.reset_cache()
+
+        assert client.state.current_interval == client.default_interval
+
+
+class TestGetCacheInfo:
+    """Tests for getting cache info."""
+
+    @patch("ai_client.anthropic.Anthropic")
+    def test_returns_empty_info_initially(self, mock_anthropic):
+        """Returns empty info initially."""
+        client = AIClient(api_key="sk-ant-test", check_interval=60)
+        info = client.get_cache_info()
+
+        assert info["last_symbol"] is None
+        assert info["last_price"] is None
+        assert info["last_call_seconds_ago"] is None
+        assert info["has_cached_decision"] is False
+        assert info["cached_decision"] is None
+
+    @patch("ai_client.anthropic.Anthropic")
+    def test_returns_filled_info_after_call(self, mock_anthropic):
+        """Returns filled info after call."""
+        mock_client = MagicMock()
+        mock_anthropic.return_value = mock_client
+        mock_response = MagicMock()
+        mock_response.content = [
+            MagicMock(text='{"decision": "buy", "reasoning": "test"}')
+        ]
+        mock_client.messages.create.return_value = mock_response
+
+        client = AIClient(api_key="sk-ant-test", check_interval=60)
+        client.should_buy("BTCUSDT", 50000, -2.5, -3.5)
+
+        info = client.get_cache_info()
+
+        assert info["last_symbol"] == "BTCUSDT"
+        assert info["last_price"] == 50000
+        assert info["last_call_seconds_ago"] is not None
+        assert info["last_call_seconds_ago"] < 1  # Just called
+        assert info["has_cached_decision"] is True
+        assert info["cached_decision"] == "buy"
+
+
+class TestPriceChangeCalculation:
+    """Tests for price change calculation."""
+
+    @patch("ai_client.anthropic.Anthropic")
+    def test_price_increase_detected(self, mock_anthropic):
+        """Detects price increase."""
+        client = AIClient(api_key="sk-ant-test", check_interval=60)
+        client.state.last_call_time = time.time() - 120
+        client.state.last_symbol = "BTCUSDT"
+        client.state.last_price = 50000
+        client.state.current_interval = 60
+        client.price_change_threshold = 0.5
+
+        # Increase 2%
+        new_price = 51000
+        assert client.is_call_needed("BTCUSDT", new_price) is True
+
+    @patch("ai_client.anthropic.Anthropic")
+    def test_price_decrease_detected(self, mock_anthropic):
+        """Detects price decrease."""
+        client = AIClient(api_key="sk-ant-test", check_interval=60)
+        client.state.last_call_time = time.time() - 120
+        client.state.last_symbol = "BTCUSDT"
+        client.state.last_price = 50000
+        client.state.current_interval = 60
+        client.price_change_threshold = 0.5
+
+        # Decrease 2%
+        new_price = 49000
+        assert client.is_call_needed("BTCUSDT", new_price) is True
+
+    @patch("ai_client.anthropic.Anthropic")
+    def test_zero_last_price_always_calls(self, mock_anthropic):
+        """With zero last price always calls."""
+        client = AIClient(api_key="sk-ant-test", check_interval=60)
+        client.state.last_call_time = time.time() - 120
+        client.state.last_symbol = "BTCUSDT"
+        client.state.last_price = 0.0  # Not set
+        client.state.current_interval = 60
+
+        assert client.is_call_needed("BTCUSDT", 50000) is True

--- a/test_ai_config.py
+++ b/test_ai_config.py
@@ -1,0 +1,103 @@
+# test_ai_config.py
+
+from ai_config import (
+    DEFAULT_MODEL,
+    DEFAULT_TIMEOUT,
+    format_user_prompt,
+    get_ai_config,
+    validate_ai_config,
+)
+
+
+class TestGetAIConfig:
+    """Tests for get_ai_config function"""
+
+    def test_returns_defaults_when_no_env_vars(self, monkeypatch):
+        """Returns default values when no environment variables"""
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+        monkeypatch.delenv("AI_MODEL", raising=False)
+        monkeypatch.delenv("AI_TIMEOUT", raising=False)
+
+        config = get_ai_config()
+
+        assert config["api_key"] is None
+        assert config["model"] == DEFAULT_MODEL
+        assert config["timeout"] == DEFAULT_TIMEOUT
+
+    def test_reads_env_vars(self, monkeypatch):
+        """Reads values from environment variables"""
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-test")
+        monkeypatch.setenv("AI_MODEL", "claude-3-opus")
+        monkeypatch.setenv("AI_TIMEOUT", "60")
+
+        config = get_ai_config()
+
+        assert config["api_key"] == "sk-ant-test"
+        assert config["model"] == "claude-3-opus"
+        assert config["timeout"] == 60
+
+
+class TestValidateAIConfig:
+    """Tests for validate_ai_config function"""
+
+    def test_rules_mode_always_valid(self):
+        """Rules mode is always valid"""
+        result = validate_ai_config("rules")
+        assert result is None
+
+    def test_ai_mode_requires_api_key(self, monkeypatch):
+        """AI mode requires API key"""
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+
+        result = validate_ai_config("ai")
+
+        assert result is not None
+        assert "ANTHROPIC_API_KEY" in result
+
+    def test_combined_mode_requires_api_key(self, monkeypatch):
+        """Combined mode requires API key"""
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+
+        result = validate_ai_config("combined")
+
+        assert result is not None
+        assert "ANTHROPIC_API_KEY" in result
+
+    def test_ai_mode_valid_with_api_key(self, monkeypatch):
+        """AI mode is valid with API key"""
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-test")
+
+        result = validate_ai_config("ai")
+
+        assert result is None
+
+    def test_invalid_mode_returns_error(self):
+        """Invalid mode returns error"""
+        result = validate_ai_config("invalid_mode")
+
+        assert result is not None
+        assert "Invalid mode" in result
+
+
+class TestFormatUserPrompt:
+    """Tests for format_user_prompt function"""
+
+    def test_formats_prompt_correctly(self):
+        """Correctly formats the prompt"""
+        prompt = format_user_prompt(
+            symbol="BTCUSDT", current_price=50000.0, change_1h=2.5, change_3h=-1.2
+        )
+
+        assert "BTCUSDT" in prompt
+        assert "50000.0" in prompt
+        assert "+2.50%" in prompt
+        assert "-1.20%" in prompt
+
+    def test_handles_negative_changes(self):
+        """Correctly handles negative changes"""
+        prompt = format_user_prompt(
+            symbol="ETHUSDT", current_price=3000.0, change_1h=-5.0, change_3h=-10.0
+        )
+
+        assert "-5.00%" in prompt
+        assert "-10.00%" in prompt

--- a/test_bot_argparse.py
+++ b/test_bot_argparse.py
@@ -1,0 +1,123 @@
+# test_bot_argparse.py
+
+import argparse
+
+import pytest
+
+
+class TestCreateArgumentParser:
+    """Tests for create_argument_parser"""
+
+    def test_parses_buy_amount_and_coin(self):
+        """Parses buy_amount and coin"""
+        from bot import create_argument_parser
+
+        parser = create_argument_parser()
+
+        args = parser.parse_args(["100", "WIF"])
+
+        assert args.buy_amount == 100.0
+        assert args.coin == "WIF"
+        assert args.mode is None
+
+    def test_parses_mode_option(self):
+        """Parses --mode option"""
+        from bot import create_argument_parser
+
+        parser = create_argument_parser()
+
+        args = parser.parse_args(["100", "WIF", "--mode", "ai"])
+
+        assert args.mode == "ai"
+
+    def test_mode_validates_choices(self):
+        """--mode accepts only valid values"""
+        from bot import create_argument_parser
+
+        parser = create_argument_parser()
+
+        with pytest.raises(SystemExit):
+            parser.parse_args(["100", "WIF", "--mode", "invalid"])
+
+    def test_whitelist_mode_no_coin(self):
+        """Whitelist mode without specifying coin"""
+        from bot import create_argument_parser
+
+        parser = create_argument_parser()
+
+        args = parser.parse_args(["100"])
+
+        assert args.buy_amount == 100.0
+        assert args.coin is None
+
+
+class TestGetDecisionMode:
+    """Tests for get_decision_mode"""
+
+    def test_cli_has_priority_over_env(self, monkeypatch):
+        """CLI has priority over .env"""
+        monkeypatch.setenv("DECISION_MODE", "combined")
+
+        from bot import get_decision_mode
+
+        args = argparse.Namespace(mode="ai")
+
+        result = get_decision_mode(args)
+
+        assert result == "ai"
+
+    def test_env_used_when_no_cli(self, monkeypatch):
+        """.env is used when no CLI argument"""
+        monkeypatch.setenv("DECISION_MODE", "combined")
+
+        from bot import get_decision_mode
+
+        args = argparse.Namespace(mode=None)
+
+        result = get_decision_mode(args)
+
+        assert result == "combined"
+
+    def test_default_when_no_cli_and_env(self, monkeypatch):
+        """Default value when no CLI and .env"""
+        monkeypatch.delenv("DECISION_MODE", raising=False)
+
+        from bot import get_decision_mode
+
+        args = argparse.Namespace(mode=None)
+
+        result = get_decision_mode(args)
+
+        assert result == "rules"
+
+
+class TestInitAIClient:
+    """Tests for init_ai_client"""
+
+    def test_returns_none_for_rules_mode(self):
+        """Returns None for rules mode"""
+        from bot import init_ai_client
+
+        result = init_ai_client("rules")
+
+        assert result is None
+
+    def test_exits_when_api_key_missing(self, monkeypatch):
+        """Exits when API key is missing"""
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+
+        from bot import init_ai_client
+
+        with pytest.raises(SystemExit):
+            init_ai_client("ai")
+
+    def test_creates_client_with_api_key(self, monkeypatch):
+        """Creates client when API key is present"""
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-test")
+
+        from bot import init_ai_client
+
+        result = init_ai_client("ai")
+
+        assert result is not None
+        assert result.api_key == "sk-ant-test"

--- a/test_evaluate_entry.py
+++ b/test_evaluate_entry.py
@@ -1,0 +1,327 @@
+# test_evaluate_entry.py
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from ai_client import AIClient, AIDecision, AIError
+from strategies import evaluate_entry
+
+
+@pytest.fixture
+def mock_ai_client():
+    """Create a mock AI client."""
+    client = MagicMock(spec=AIClient)
+    return client
+
+
+class TestRulesMode:
+    """Tests for rules mode."""
+
+    def test_quick_rise_triggers_buy(self):
+        """Quick rise triggers buy."""
+        should_buy, source = evaluate_entry(
+            decision_mode="rules",
+            ai_client=None,
+            symbol="BTCUSDT",
+            current_price=50000,
+            quick_price_change=4.0,  # > 3%
+            price_change=-1.0,
+            quick_rise_threshold=3.0,
+            price_drop_threshold=-3.0,
+        )
+
+        assert should_buy is True
+        assert source == "rules_quick_rise"
+
+    def test_price_drop_triggers_buy(self):
+        """Price drop triggers buy."""
+        should_buy, source = evaluate_entry(
+            decision_mode="rules",
+            ai_client=None,
+            symbol="BTCUSDT",
+            current_price=50000,
+            quick_price_change=1.0,
+            price_change=-4.0,  # < -3%
+            quick_rise_threshold=3.0,
+            price_drop_threshold=-3.0,
+        )
+
+        assert should_buy is True
+        assert source == "rules_price_drop"
+
+    def test_no_signal_holds(self):
+        """No signal — hold."""
+        should_buy, source = evaluate_entry(
+            decision_mode="rules",
+            ai_client=None,
+            symbol="BTCUSDT",
+            current_price=50000,
+            quick_price_change=1.0,
+            price_change=-1.0,
+            quick_rise_threshold=3.0,
+            price_drop_threshold=-3.0,
+        )
+
+        assert should_buy is False
+        assert source == "hold"
+
+    def test_ignores_ai_client(self, mock_ai_client):
+        """Rules mode ignores AI client."""
+        should_buy, source = evaluate_entry(
+            decision_mode="rules",
+            ai_client=mock_ai_client,
+            symbol="BTCUSDT",
+            current_price=50000,
+            quick_price_change=1.0,
+            price_change=-1.0,
+            quick_rise_threshold=3.0,
+            price_drop_threshold=-3.0,
+        )
+
+        assert should_buy is False
+        mock_ai_client.should_buy.assert_not_called()
+
+
+class TestAIMode:
+    """Tests for ai mode."""
+
+    def test_ai_buy_decision(self, mock_ai_client):
+        """AI decides to buy."""
+        mock_ai_client.should_buy.return_value = AIDecision(
+            decision="buy", reasoning="Strong momentum"
+        )
+
+        should_buy, source = evaluate_entry(
+            decision_mode="ai",
+            ai_client=mock_ai_client,
+            symbol="BTCUSDT",
+            current_price=50000,
+            quick_price_change=1.0,
+            price_change=-1.0,
+            quick_rise_threshold=3.0,
+            price_drop_threshold=-3.0,
+        )
+
+        assert should_buy is True
+        assert source == "ai"
+        mock_ai_client.should_buy.assert_called_once()
+
+    def test_ai_hold_decision(self, mock_ai_client):
+        """AI decides to hold."""
+        mock_ai_client.should_buy.return_value = AIDecision(
+            decision="hold", reasoning="Weak momentum"
+        )
+
+        should_buy, source = evaluate_entry(
+            decision_mode="ai",
+            ai_client=mock_ai_client,
+            symbol="BTCUSDT",
+            current_price=50000,
+            quick_price_change=5.0,  # Rules would trigger
+            price_change=-5.0,
+            quick_rise_threshold=3.0,
+            price_drop_threshold=-3.0,
+        )
+
+        assert should_buy is False
+        assert source == "hold"
+
+    def test_ai_error_fallback_to_rules(self, mock_ai_client):
+        """On AI error — fallback to rules."""
+        mock_ai_client.should_buy.side_effect = AIError("API Error")
+
+        should_buy, source = evaluate_entry(
+            decision_mode="ai",
+            ai_client=mock_ai_client,
+            symbol="BTCUSDT",
+            current_price=50000,
+            quick_price_change=5.0,  # Rules will trigger
+            price_change=-1.0,
+            quick_rise_threshold=3.0,
+            price_drop_threshold=-3.0,
+        )
+
+        assert should_buy is True
+        assert source == "rules (ai_unavailable)"
+
+    def test_ai_error_no_rules_signal(self, mock_ai_client):
+        """On AI error and no rules signal — hold."""
+        mock_ai_client.should_buy.side_effect = AIError("API Error")
+
+        should_buy, source = evaluate_entry(
+            decision_mode="ai",
+            ai_client=mock_ai_client,
+            symbol="BTCUSDT",
+            current_price=50000,
+            quick_price_change=1.0,  # Rules won't trigger
+            price_change=-1.0,
+            quick_rise_threshold=3.0,
+            price_drop_threshold=-3.0,
+        )
+
+        assert should_buy is False
+        assert source == "hold"
+
+    def test_none_ai_client_fallback(self):
+        """None AI client — fallback to rules."""
+        should_buy, source = evaluate_entry(
+            decision_mode="ai",
+            ai_client=None,
+            symbol="BTCUSDT",
+            current_price=50000,
+            quick_price_change=5.0,
+            price_change=-1.0,
+            quick_rise_threshold=3.0,
+            price_drop_threshold=-3.0,
+        )
+
+        assert should_buy is True
+        assert source == "rules (ai_unavailable)"
+
+
+class TestCombinedMode:
+    """Tests for combined mode."""
+
+    def test_no_rules_signal_no_ai_call(self, mock_ai_client):
+        """No rules signal — AI is not called."""
+        should_buy, source = evaluate_entry(
+            decision_mode="combined",
+            ai_client=mock_ai_client,
+            symbol="BTCUSDT",
+            current_price=50000,
+            quick_price_change=1.0,
+            price_change=-1.0,
+            quick_rise_threshold=3.0,
+            price_drop_threshold=-3.0,
+        )
+
+        assert should_buy is False
+        assert source == "hold"
+        mock_ai_client.should_buy.assert_not_called()
+
+    def test_rules_signal_ai_confirms(self, mock_ai_client):
+        """Rules triggered, AI confirmed."""
+        mock_ai_client.should_buy.return_value = AIDecision(
+            decision="buy", reasoning="Confirmed"
+        )
+
+        should_buy, source = evaluate_entry(
+            decision_mode="combined",
+            ai_client=mock_ai_client,
+            symbol="BTCUSDT",
+            current_price=50000,
+            quick_price_change=5.0,
+            price_change=-1.0,
+            quick_rise_threshold=3.0,
+            price_drop_threshold=-3.0,
+        )
+
+        assert should_buy is True
+        assert source == "rules+ai"
+
+    def test_rules_signal_ai_vetoes(self, mock_ai_client):
+        """Rules triggered, AI rejected."""
+        mock_ai_client.should_buy.return_value = AIDecision(
+            decision="hold", reasoning="Not a good entry"
+        )
+
+        should_buy, source = evaluate_entry(
+            decision_mode="combined",
+            ai_client=mock_ai_client,
+            symbol="BTCUSDT",
+            current_price=50000,
+            quick_price_change=5.0,
+            price_change=-1.0,
+            quick_rise_threshold=3.0,
+            price_drop_threshold=-3.0,
+        )
+
+        assert should_buy is False
+        assert source == "ai_veto"
+
+    def test_rules_signal_ai_error_fallback(self, mock_ai_client):
+        """Rules triggered, AI error — fallback."""
+        mock_ai_client.should_buy.side_effect = AIError("API Error")
+
+        should_buy, source = evaluate_entry(
+            decision_mode="combined",
+            ai_client=mock_ai_client,
+            symbol="BTCUSDT",
+            current_price=50000,
+            quick_price_change=5.0,
+            price_change=-1.0,
+            quick_rise_threshold=3.0,
+            price_drop_threshold=-3.0,
+        )
+
+        assert should_buy is True
+        assert source == "rules (ai_unavailable)"
+
+    def test_none_ai_client_uses_rules(self):
+        """None AI client — only rules are used."""
+        should_buy, source = evaluate_entry(
+            decision_mode="combined",
+            ai_client=None,
+            symbol="BTCUSDT",
+            current_price=50000,
+            quick_price_change=5.0,
+            price_change=-1.0,
+            quick_rise_threshold=3.0,
+            price_drop_threshold=-3.0,
+        )
+
+        assert should_buy is True
+        assert source == "rules (ai_unavailable)"
+
+
+class TestEdgeCases:
+    """Tests for edge cases."""
+
+    def test_unknown_mode_defaults_to_rules(self):
+        """Unknown mode — fallback to rules."""
+        should_buy, source = evaluate_entry(
+            decision_mode="unknown_mode",
+            ai_client=None,
+            symbol="BTCUSDT",
+            current_price=50000,
+            quick_price_change=5.0,
+            price_change=-1.0,
+            quick_rise_threshold=3.0,
+            price_drop_threshold=-3.0,
+        )
+
+        assert should_buy is True
+        assert source == "rules"
+
+    def test_exact_threshold_triggers(self):
+        """Exact threshold value triggers signal."""
+        should_buy, source = evaluate_entry(
+            decision_mode="rules",
+            ai_client=None,
+            symbol="BTCUSDT",
+            current_price=50000,
+            quick_price_change=3.0,  # Exactly at threshold
+            price_change=-1.0,
+            quick_rise_threshold=3.0,
+            price_drop_threshold=-3.0,
+        )
+
+        assert should_buy is True
+        assert source == "rules_quick_rise"
+
+    def test_both_conditions_met_quick_rise_priority(self):
+        """When both conditions are met — quick rise has priority."""
+        should_buy, source = evaluate_entry(
+            decision_mode="rules",
+            ai_client=None,
+            symbol="BTCUSDT",
+            current_price=50000,
+            quick_price_change=5.0,
+            price_change=-5.0,
+            quick_rise_threshold=3.0,
+            price_drop_threshold=-3.0,
+        )
+
+        assert should_buy is True
+        assert source == "rules_quick_rise"

--- a/test_strategies_params.py
+++ b/test_strategies_params.py
@@ -1,0 +1,137 @@
+# test_strategies_params.py
+
+from strategies import evaluate_entry
+
+
+class TestEvaluateEntry:
+    """Tests for evaluate_entry function"""
+
+    def test_rules_mode_quick_rise(self):
+        """Rules mode: quick rise triggers"""
+        should_buy, source = evaluate_entry(
+            decision_mode="rules",
+            ai_client=None,
+            symbol="BTCUSDT",
+            current_price=50000.0,
+            quick_price_change=3.5,  # >= 3.0
+            price_change=1.0,
+            quick_rise_threshold=3.0,
+            price_drop_threshold=-3.0,
+        )
+
+        assert should_buy is True
+        assert source == "rules_quick_rise"
+
+    def test_rules_mode_price_drop(self):
+        """Rules mode: price drop triggers"""
+        should_buy, source = evaluate_entry(
+            decision_mode="rules",
+            ai_client=None,
+            symbol="BTCUSDT",
+            current_price=50000.0,
+            quick_price_change=1.0,
+            price_change=-3.5,  # <= -3.0
+            quick_rise_threshold=3.0,
+            price_drop_threshold=-3.0,
+        )
+
+        assert should_buy is True
+        assert source == "rules_price_drop"
+
+    def test_rules_mode_no_signal(self):
+        """Rules mode: no signal"""
+        should_buy, source = evaluate_entry(
+            decision_mode="rules",
+            ai_client=None,
+            symbol="BTCUSDT",
+            current_price=50000.0,
+            quick_price_change=1.0,  # < 3.0
+            price_change=-1.0,  # > -3.0
+            quick_rise_threshold=3.0,
+            price_drop_threshold=-3.0,
+        )
+
+        assert should_buy is False
+        assert source == "hold"
+
+    def test_ai_mode_stub_uses_rules(self):
+        """Stub: ai mode uses rules"""
+        should_buy, source = evaluate_entry(
+            decision_mode="ai",
+            ai_client=None,
+            symbol="BTCUSDT",
+            current_price=50000.0,
+            quick_price_change=3.5,
+            price_change=1.0,
+            quick_rise_threshold=3.0,
+            price_drop_threshold=-3.0,
+        )
+
+        assert should_buy is True
+        assert "ai_unavailable" in source
+
+    def test_combined_mode_stub_uses_rules(self):
+        """Stub: combined mode uses rules"""
+        should_buy, source = evaluate_entry(
+            decision_mode="combined",
+            ai_client=None,
+            symbol="BTCUSDT",
+            current_price=50000.0,
+            quick_price_change=3.5,
+            price_change=1.0,
+            quick_rise_threshold=3.0,
+            price_drop_threshold=-3.0,
+        )
+
+        assert should_buy is True
+        assert "ai_unavailable" in source
+
+    def test_unknown_mode_returns_hold(self):
+        """Unknown mode falls back to rules"""
+        should_buy, source = evaluate_entry(
+            decision_mode="unknown",
+            ai_client=None,
+            symbol="BTCUSDT",
+            current_price=50000.0,
+            quick_price_change=5.0,
+            price_change=-5.0,
+            quick_rise_threshold=3.0,
+            price_drop_threshold=-3.0,
+        )
+
+        # For unknown mode, function falls back to rules
+        # and returns True if rules triggered
+        assert should_buy is True
+        assert source == "rules"
+
+
+class TestStrategySignatures:
+    """Tests for strategy function signatures"""
+
+    def test_run_trailing_stop_strategy_accepts_new_params(self):
+        """run_trailing_stop_strategy accepts new parameters"""
+        import inspect
+
+        from strategies import run_trailing_stop_strategy
+
+        sig = inspect.signature(run_trailing_stop_strategy)
+        params = sig.parameters
+
+        assert "decision_mode" in params
+        assert "ai_client" in params
+        assert params["decision_mode"].default == "rules"
+        assert params["ai_client"].default is None
+
+    def test_run_trailing_stop_strategy_whitelist_accepts_new_params(self):
+        """run_trailing_stop_strategy_whitelist accepts new parameters"""
+        import inspect
+
+        from strategies import run_trailing_stop_strategy_whitelist
+
+        sig = inspect.signature(run_trailing_stop_strategy_whitelist)
+        params = sig.parameters
+
+        assert "decision_mode" in params
+        assert "ai_client" in params
+        assert params["decision_mode"].default == "rules"
+        assert params["ai_client"].default is None


### PR DESCRIPTION
- Added AIClient module for interaction with Anthropic Claude API to make trading decisions.
- Introduced AI configuration options in .env.example for API key, model, timeout, and decision modes.
- Enhanced bot functionality to support three decision modes: rules, AI-only, and combined (rules + AI confirmation).
- Updated README.md with detailed instructions on AI integration and usage examples.
- Implemented unit tests for AIClient and related functionalities to ensure reliability.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds Anthropic AI decision-making (rules/ai/combined), updates bot CLI and strategies to use it, expands config/docs, and adds comprehensive tests.
> 
> - **AI Integration**:
>   - New `ai_client.py` with Anthropic client, JSON parsing, caching, rate limiting, retries, and backoff.
>   - New `ai_config.py` with defaults, prompts, env-driven config, and validation.
> - **Strategies**:
>   - Unified entry logic via `evaluate_entry` and AI-aware whitelist selection in `strategies.py`.
>   - Strategy runners accept `decision_mode` and optional `ai_client`.
> - **Bot/CLI**:
>   - `bot.py` uses `argparse`, adds `--mode {rules,ai,combined}`, resolves mode (CLI > env), and initializes AI client conditionally.
> - **Config/Docs**:
>   - Added `.env.example` with AI settings; updated `README.md` with setup, modes, and cost/monitoring notes.
>   - `.gitignore` tweaked to keep `.env.example`.
> - **Tests**:
>   - New tests for `AIClient`, config, CLI parsing, and strategy decision logic (`test_ai_client*.py`, `test_ai_config.py`, `test_bot_argparse.py`, `test_evaluate_entry.py`, `test_strategies_params.py`).
> - **Dependencies**:
>   - Added `anthropic` to `requirements.txt`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c916cf16d40999b2c02afbf9dffd9f12a9bcaa23. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->